### PR TITLE
Add builder to wait for kubectl jobs to finish

### DIFF
--- a/kubectl_wait_for_job/Dockerfile
+++ b/kubectl_wait_for_job/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/gcloud
+
+COPY kubectl_wait_for_job.bash /builder/kubectl_wait_for_job.bash
+
+ENTRYPOINT ["/builder/kubectl_wait_for_job.bash"]

--- a/kubectl_wait_for_job/README.md
+++ b/kubectl_wait_for_job/README.md
@@ -1,0 +1,53 @@
+# Tool builder: `gcr.io/cloud-builders/kubectl_wait_for_job`
+
+This Container Builder build step runs
+[`kubectl_wait_for_job`](https://kubernetes.io/docs/user-guide/kubectl-overview/).
+
+## Using this builder with Google Container Engine
+
+To use this builder, your
+[builder service account](https://cloud.google.com/container-builder/docs/how-to/service-account-permissions)
+will need IAM permissions sufficient for the operations you want to perform. For
+typical read-only usage, the "Container Engine Viewer" role is sufficient. To
+deploy container images on a GKE cluster, the "Container Engine Developer" role
+is sufficient. Check the
+[GKE IAM page](https://cloud.google.com/container-engine/docs/iam-integration)
+for details.
+
+Running the following command will give Container Builder Service Account
+`container.developer` role access to your Container Engine clusters:
+
+```sh
+PROJECT="$(gcloud projects describe \
+    $(gcloud config get-value core/project -q) --format='get(projectNumber)')"
+
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member=serviceAccount:$PROJECT@cloudbuild.gserviceaccount.com \
+    --role=roles/container.developer
+```
+
+For most use, kubectl will need to be configured to point to a specific GKE
+cluster. You can configure the cluster by setting environment variables.
+
+    CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+    CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
+
+
+If your GKE cluster is in a different project than Container Builder, also set:
+
+```CLOUDSDK_CORE_PROJECT=<the GKE cluster project>```
+
+Make sure you also grant the Container Builder service account permissions in the GKE cluster project.
+
+Setting the environment variables above will cause this step's entrypoint to
+first run a command to fetch cluster credentials as follows.
+
+    gcloud container clusters get-credentials --zone "$CLOUDSDK_COMPUTE_ZONE" "$CLOUDSDK_CONTAINER_CLUSTER"`
+
+Then, `kubectl_wait_for_job` will have the configuration needed to talk to your GKE cluster.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud container builds submit . --config=cloudbuild.yaml

--- a/kubectl_wait_for_job/README.md
+++ b/kubectl_wait_for_job/README.md
@@ -3,6 +3,8 @@
 This Container Builder build step runs
 [`kubectl_wait_for_job`](https://kubernetes.io/docs/user-guide/kubectl-overview/).
 
+If you're looking to run a job but actually block execution until that job is complete on the cluster, this wraps the kubectl command to do that. For instance if you need run database migrations prior to deploying the code that utilizes them, you can use this command to execute a job, wait for it to complete, and then update your deployment with the image that utilizes those migrations.  
+
 ## Using this builder with Google Container Engine
 
 To use this builder, your

--- a/kubectl_wait_for_job/cloudbuild.yaml
+++ b/kubectl_wait_for_job/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/kubectl_wait_for_job', 'kubectl_wait_for_job/.']
+
+images: ['gcr.io/$PROJECT_ID/kubectl_wait_for_job']

--- a/kubectl_wait_for_job/examples/pods-list/cloudbuild.yaml
+++ b/kubectl_wait_for_job/examples/pods-list/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/kubectl_wait_for_job'
+  args: ['job_name]
+  env:
+  - 'CLOUDSDK_COMPUTE_ZONE=us-east4-b'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=your-cluster'

--- a/kubectl_wait_for_job/kubectl_wait_for_job.bash
+++ b/kubectl_wait_for_job/kubectl_wait_for_job.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# If there is no current context, get one.
+if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
+    cluster=$(gcloud config get-value container/cluster 2> /dev/null)
+    zone=$(gcloud config get-value compute/zone 2> /dev/null)
+    project=$(gcloud config get-value core/project 2> /dev/null)
+
+    function var_usage() {
+        cat <<EOF
+No cluster is set. To set the cluster (and the zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone>
+  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+EOF
+        exit 1
+    }
+
+    [[ -z "$cluster" ]] && var_usage
+    [[ -z "$zone" ]] && var_usage
+
+    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+fi
+
+echo "Running: kubectl  wait for job $@"
+until kubectl get jobs "$@" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' | grep True ; do sleep 1 ; done


### PR DESCRIPTION
This builder lets you wait for a Kubernetes job to finish before moving to the next step. It's useful for things like database migrations. 