### PR TITLE
Update README's to remove `cloud-builders` registry

### DIFF
--- a/fsharp/README.md
+++ b/fsharp/README.md
@@ -6,10 +6,10 @@ See [docs](https://cloud.google.com/container-builder/docs/concepts/custom-build
 
 ```
 steps:
-- name: gcr.io/cloud-builders/fsharp
+- name: gcr.io/$PROJECT_ID/fsharp
   id: fsharp-version
   args: ['fsharpc', '--help']
-- name: gcr.io/cloud-builders/fsharp
+- name: gcr.io/$PROJECT_ID/fsharp
   id: fsharp-build
   args: ['msbuild', '/p:Configuration=Release', 'src/App.sln']
 ```

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,7 +1,4 @@
-# Tool builder: `gcr.io/cloud-builders/helm`
-
-This Container Builder build step runs
-[`helm`](https://docs.helm.sh/).
+# [Helm] tool builder(https://docs.helm.sh/)
 
 ## Using this builder with Google Container Engine
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,4 +1,4 @@
-# [Helm] tool builder(https://docs.helm.sh/)
+# [Helm](https://docs.helm.sh/) tool builder
 
 ## Using this builder with Google Container Engine
 

--- a/kubectl_wait_for_job/README.md
+++ b/kubectl_wait_for_job/README.md
@@ -1,7 +1,4 @@
-# Tool builder: `gcr.io/cloud-builders/kubectl_wait_for_job`
-
-This Container Builder build step runs
-[`kubectl_wait_for_job`](https://kubernetes.io/docs/user-guide/kubectl-overview/).
+# [`kubectp_wait_for_job`](https://kubernetes.io/docs/user-guide/kubectl-overview) tool builder
 
 If you're looking to run a job but actually block execution until that job is complete on the cluster, this wraps the kubectl command to do that. For instance if you need run database migrations prior to deploying the code that utilizes them, you can use this command to execute a job, wait for it to complete, and then update your deployment with the image that utilizes those migrations.  
 


### PR DESCRIPTION
Builders in this repo (except `glide` for historical reasons) are not hosted in the `gcr.io/cloud-builders/...` registry. They are intended to be built by projects that use them, and hosted in a registry accessible to that project.