### PR TITLE
fix role and gcloud instance cleanup

### DIFF
--- a/remote-builder/README.md
+++ b/remote-builder/README.md
@@ -73,7 +73,7 @@ export PROJECT=$(gcloud info --format='value(config.project)')
 export PROJECT_NUMBER=$(gcloud projects describe $PROJECT --format 'value(projectNumber)')
 export CB_SA_EMAIL=$PROJECT_NUMBER@cloudbuild.gserviceaccount.com
 gcloud services enable cloudbuild.googleapis.com
-gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$CB_SA_EMAIL --role='roles/iam.serviceAccountUser' --role='roles/compute.instanceAdmin'
+gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$CB_SA_EMAIL --role='roles/iam.serviceAccountUser' --role='roles/compute.instanceAdmin' --role='roles/iam.serviceAccountActor'
 ```
 
 2. Create the build request:

--- a/remote-builder/run-builder.sh
+++ b/remote-builder/run-builder.sh
@@ -2,7 +2,7 @@
 
 # Always delete instance after attempting build
 function cleanup {
-    gcloud compute instances delete ${INSTANCE_NAME}
+    gcloud compute instances delete ${INSTANCE_NAME} --quiet
 }
 
 # Configurable parameters


### PR DESCRIPTION
adds required serviceAccountActor role and quiets the instance deletion.