### PR TITLE
Make builder

### DIFF
--- a/make/Dockerfile
+++ b/make/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian
+
+RUN apt-get update && \
+  apt-get install -y ca-certificates curl wget build-essential
+
+ENTRYPOINT ["make"]

--- a/make/README.md
+++ b/make/README.md
@@ -1,0 +1,15 @@
+# Make
+
+This build step provides a container with the build-essentials package
+installed.  It is intended for running Make targets composed of shell commands,
+such as targets that make modifications to a Dockerfile.
+
+It is capable of running simple GCC builds, but the primary use is in conjuction
+with other containers as part of a Google Container Builder configuration.
+
+The entrypoint for this container is bash, so it is necessary to include the
+whole make command.  For example:
+
+steps:
+- name: 'gcr.io/cloud-community-builders/make
+  args: ['build']

--- a/make/cloudbuild.yaml
+++ b/make/cloudbuild.yaml
@@ -1,0 +1,11 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud container builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/make', '.']
+- name: 'gcr.io/$PROJECT_ID/make'
+  args: ['-v']
+
+images:
+- 'gcr.io/$PROJECT_ID/make'

--- a/make/examples/Makefile
+++ b/make/examples/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "Hello Make!"

--- a/make/examples/README.md
+++ b/make/examples/README.md
@@ -1,0 +1,22 @@
+# Make builder
+
+This builder can be used to execute simple make targets without non-standard
+dependencies.  It's intended use is for executing simple make targets that
+perform tasks like preparing a workspace for a Docker build.
+
+This assumes you have already built the `make` build step and pushed it to
+`gcr.io/$PROJECT_ID/make`.
+
+## Executing the builder
+
+Inside this directory, run the following command:
+
+```
+gcloud container builds submit --config=cloudbuild.yaml .
+```
+
+Build output will be displayed.  At the end you should see the following:
+
+```
+Hello Make!
+```

--- a/make/examples/cloudbuild.yaml
+++ b/make/examples/cloudbuild.yaml
@@ -1,0 +1,6 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud container builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: gcr.io/$PROJECT_ID/make
+  args: ['all']


### PR DESCRIPTION
Allows execution of simple Make targets such as targets that execute shell commands to prepare a workspace.  This can be useful when replacing existing Make builds with Google Container Builder configs.