### PR TITLE
Upgrade helm to 2.8.1, support regional GKE clusters, cleanup

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,9 +1,21 @@
 FROM gcr.io/cloud-builders/gcloud
+
+ENV VERSION v2.8.1
+
 COPY helm.bash /builder/helm.bash
-RUN chmod +x /builder/helm.bash && mkdir -p /builder/helm && apt-get update && apt-get install -y curl \
-    && curl -SL https://storage.googleapis.com/kubernetes-helm/helm-v2.5.1-linux-amd64.tar.gz -o helm.tar.gz \
-    && tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm \
-    && rm helm.tar.gz \
-    && apt-get remove --purge -y curl && apt-get --purge -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN chmod +x /builder/helm.bash && \
+  mkdir -p /builder/helm && \
+  apt-get update && \
+  apt-get install -y curl && \
+  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm && \
+  rm helm.tar.gz && \
+  apt-get remove --purge -y curl && \
+  apt-get --purge -y autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 ENV PATH=/builder/helm/:$PATH
+
 ENTRYPOINT ["/builder/helm.bash"]

--- a/helm/README.md
+++ b/helm/README.md
@@ -14,8 +14,17 @@ for details.
 For most use, kubectl will need to be configured to point to a specific GKE
 cluster. You can configure the cluster by setting environment variables.
 
+    # Set region for regional GKE clusters or Zone for Zonal clusters
+    CLOUDSDK_COMPUTE_REGION=<your cluster's region>
+    or
     CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+
+    # Name of GKE cluster
     CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
+
+    # (Optional) Project of GKE Cluster, only if you want helm to authenticate
+    # to a GKE cluster in another project (requires IAM Service Accounts are properly setup)
+    GCLOUD_PROJECT=<destination cluster's GCP project>
 
 Setting the environment variables above will cause this step's entrypoint to
 first run a command to fetch cluster credentials as follows.

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,5 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '.']
+  args: ['build', '--tag=gcr.io/$_PROJECT_ID/helm', 'helm']
 
-images: ['gcr.io/$PROJECT_ID/helm']
+images: ['gcr.io/$_PROJECT_ID/helm']
+
+substitutions:
+  _PROJECT_ID: '$PROJECT_ID'

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -2,24 +2,34 @@
 
 # If there is no current context, get one.
 if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
-    cluster=$(gcloud config get-value container/cluster 2> /dev/null)
-    zone=$(gcloud config get-value compute/zone 2> /dev/null)
-    project=$(gcloud config get-value core/project 2> /dev/null)
+    # This tries to read environment variables. If not set, it grabs from gcloud
+    cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+    region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+    zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+    project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
 
     function var_usage() {
         cat <<EOF
-No cluster is set. To set the cluster (and the zone where it is found), set the environment variables
-  CLOUDSDK_COMPUTE_ZONE=<cluster zone>
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
   CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
 EOF
         exit 1
     }
 
     [[ -z "$cluster" ]] && var_usage
-    [[ -z "$zone" ]] && var_usage
+    [ ! "$zone" -o "$region" ] && var_usage
 
-    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+    if [ -n "$region" ]; then
+      echo "Running: gcloud config set container/use_v1_api_client false"
+      gcloud config set container/use_v1_api_client false
+      echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+    else
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+    fi
 fi
 
 echo "Running: helm init --client-only"


### PR DESCRIPTION
Changes:
* Upgrade helm to 2.8.1
* Cleaned up Dockerfile to be more readable
* Updated /helm/cloudbuilder.yaml to support pushing to repos outside of GCP project that built the image (to push to a public repo, for example)
* Pull in GCP/GKE projects, GKE cluster, region, & zone from env vars in the helm docker image if supplied. Otherwise, use the same gcloud commnads to discover.
* Default to beta region gcloud API if a region is passed in