### PR TITLE
Add skaffold step (alpha)

### DIFF
--- a/skaffold/Dockerfile
+++ b/skaffold/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/cloud-builders/kubectl
+
+RUN mkdir -p /builder/bin && \
+	curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/v0.1.0/skaffold-linux-amd64 && \
+	chmod +x /builder/bin/skaffold
+ENV PATH=/builder/bin/:$PATH
+
+COPY skaffold.bash /builder/skaffold.bash
+
+ENTRYPOINT ["/builder/skaffold.bash"]

--- a/skaffold/README.md
+++ b/skaffold/README.md
@@ -1,0 +1,34 @@
+# `gcr.io/cloud-builders-community/skaffold:alpha`
+
+This Container Builder build step runs
+[`skaffold`](https://github.com/GoogleCloudPlatform/skaffold/) for Google
+Kubernetes Engine (GKE) clusters.
+
+> **NOTE:** This builder image is using pre-stable versions of Skaffold and
+> is **NOT RECOMMENDED** for production use.
+
+## Using this builder
+
+This builder is derived from the [`kubectl` builder](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/kubectl)
+and therefore supports the same environment variables. Read the `kubectl` builder
+documentation to use Skaffold builder.
+
+## Example: Deploying to Google Kubernetes Engine
+
+To run `skaffold run` in your cloudbuild.yaml, include this step with the
+correct Kubernetes Engine cluster name and compute zone:
+
+```
+steps:
+- name: gcr.io/cloud-builders-community/skaffold:alpha
+  args: ['run', '-f=skaffold.yaml']
+  env:
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-a'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=[YOUR_CLUSTER_NAME]'
+  ```
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud container builds submit . --config=cloudbuild.yaml

--- a/skaffold/cloudbuild.yaml
+++ b/skaffold/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/skaffold:alpha', '.']
+
+images: ['gcr.io/$PROJECT_ID/skaffold:alpha']

--- a/skaffold/skaffold.bash
+++ b/skaffold/skaffold.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Invoke kubectl.bash to process CLOUDSDK_* environment variables and make a
+# call to the cluster to verify connectivity.
+/builder/kubectl.bash version
+
+echo "Running: skaffold $@"
+skaffold "$@"


### PR DESCRIPTION
Derived from the official kubectl builder, this works with GKE as well.

Explicitly marking this as `:alpha` so users are aware what they are deploying
is pre-stable material.

I'm using this right now and seems to be working fine.
