### PR TITLE
Fix helm builder

### DIFF
--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,8 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$_PROJECT_ID/helm', 'helm']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '.']
 
-images: ['gcr.io/$_PROJECT_ID/helm']
-
-substitutions:
-  _PROJECT_ID: '$PROJECT_ID'
+images: ['gcr.io/$PROJECT_ID/helm']


### PR DESCRIPTION
- substituting `$_PROJECT_ID` with `$PROJECT_ID` doesn't cascade; `$PROJECT_ID` is not further substituted with the build's project ID
- the `docker build` should build the contents of `.`, not the `helm/` directory, which is not found inside `helm/`