### PR TITLE
Update skaffold version

### DIFF
--- a/skaffold/Dockerfile
+++ b/skaffold/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/kubectl
 
 RUN mkdir -p /builder/bin && \
-	curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/v0.1.0/skaffold-linux-amd64 && \
+	curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/latest/skaffold-linux-amd64 && \
 	chmod +x /builder/bin/skaffold
 ENV PATH=/builder/bin/:$PATH
 


### PR DESCRIPTION
There's been a few skaffold releases after v0.1.0, currently on v.0.5.0. This change will allow to install the latest skaffold version.