### PR TITLE
Add buildah builder

### DIFF
--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -1,0 +1,31 @@
+FROM launcher.gcr.io/google/ubuntu16_04
+
+RUN \
+  # Install runc
+  apt-get update && \
+  apt-get -y install wget && \
+  wget -O /bin/runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64 && \
+  chmod +x /bin/runc && \
+  PATH=/usr/local/bin/:$PATH && \
+  runc --help && \
+  # Install buildah dependencies
+  apt-get -y install software-properties-common && \
+  add-apt-repository -y ppa:alexlarsson/flatpak && \
+  add-apt-repository -y ppa:gophers/archive && \
+  apt-add-repository -y ppa:projectatomic/ppa && \
+  apt-get -y -qq update && \
+  apt-get -y install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libostree-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man wget && \
+  apt-get -y install golang-1.8 && \
+  # Install buildah
+  mkdir -p /builder/buildah && \
+  cd /builder/buildah && \
+  export GOPATH=`pwd` && \
+  git clone https://github.com/projectatomic/buildah ./src/github.com/projectatomic/buildah && \
+  cd ./src/github.com/projectatomic/buildah && \
+  PATH=/usr/lib/go-1.8/bin:$PATH make runc all TAGS="apparmor seccomp" && \
+  cd /builder/buildah/src/github.com/projectatomic/buildah && \
+  ls -lh && \
+  make install install.runc && \
+  buildah --help
+
+ENTRYPOINT ["buildah"]

--- a/buildah/Dockerfile
+++ b/buildah/Dockerfile
@@ -1,14 +1,14 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
 RUN \
-  # Install runc
-  apt-get update && \
+  # Install runc first, fail fast if something is wrong.
+  apt-get -y -qq update && \
   apt-get -y install wget && \
   wget -O /bin/runc https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64 && \
   chmod +x /bin/runc && \
   PATH=/usr/local/bin/:$PATH && \
   runc --help && \
-  # Install buildah dependencies
+  # Install buildah dependencies.
   apt-get -y install software-properties-common && \
   add-apt-repository -y ppa:alexlarsson/flatpak && \
   add-apt-repository -y ppa:gophers/archive && \
@@ -16,7 +16,7 @@ RUN \
   apt-get -y -qq update && \
   apt-get -y install bats btrfs-tools git libapparmor-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libostree-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man wget && \
   apt-get -y install golang-1.8 && \
-  # Install buildah
+  # Install buildah.
   mkdir -p /builder/buildah && \
   cd /builder/buildah && \
   export GOPATH=`pwd` && \

--- a/buildah/Dockerfile.sample
+++ b/buildah/Dockerfile.sample
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/wget
+
+RUN wget https://google.com
+
+ENTRYPOINT ["echo", "hello"]

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -1,0 +1,14 @@
+# Buildah
+
+This builder builds container images using Project Atomic's
+[Buildah](https://github.com/projectatomic/buildah) tool, which is capable of
+building and pushing container images without requiring access to the Docker
+daemon socket.
+
+This builder can be built and pushed to your GCR repository by running
+
+```
+gcloud container builds submit --config=cloudbuild.yaml
+```
+
+in this directory

--- a/buildah/cloudbuild.yaml
+++ b/buildah/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/buildah', '.']
+
+- name: gcr.io/$PROJECT_ID/buildah
+  args: ['bud', '-t', 'image', '-f', 'Dockerfile.sample', '--format=docker', '.']
+  volumes:
+  - name: varlibcontainers
+    path: '/var/lib/containers'
+
+- name: gcr.io/$PROJECT_ID/buildah
+  args: ['push', 'image', 'docker://gcr.io/$PROJECT_ID/pushed-by-buildah']
+  volumes:
+  - name: varlibcontainers
+    path: '/var/lib/containers'
+
+images: ['gcr.io/$PROJECT_ID/buildah']


### PR DESCRIPTION
This builder is capable of building and pushing container images from Dockerfiles (using `buildah bud`) or using Buildah's own declarative style, without access to the Docker daemon socket.