### PR TITLE
Fix skaffold releases url and docker config

### DIFF
--- a/skaffold/Dockerfile
+++ b/skaffold/Dockerfile
@@ -1,9 +1,17 @@
 FROM gcr.io/cloud-builders/kubectl
 
 RUN mkdir -p /builder/bin && \
-	curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/latest/skaffold-linux-amd64 && \
-	chmod +x /builder/bin/skaffold
+  apt-get update && \
+  apt-get install -y curl && \
+  curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && \
+  chmod +x /builder/bin/skaffold && \
+  apt-get remove --purge -y curl && \
+  apt-get --purge -y autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 ENV PATH=/builder/bin/:$PATH
+ENV DOCKER_CONFIG=/builder/home/.docker
 
 COPY skaffold.bash /builder/skaffold.bash
 

--- a/skaffold/skaffold.bash
+++ b/skaffold/skaffold.bash
@@ -5,5 +5,7 @@ set -e
 # call to the cluster to verify connectivity.
 /builder/kubectl.bash version
 
+gcloud auth configure-docker
+
 echo "Running: skaffold $@"
 skaffold "$@"


### PR DESCRIPTION
This ensures curl is installed before using it and cleans it up after.

It fixes the download url, since the current one doesn't points to the latest release.

It runs `gcloud auth configure-docker` and it sets the `DOCKER_CONFIG` since it default's to home but the last commands puts it on `/builder/home/.docker`, to let skaffold authenticated docker commands.

Not included in this PR but skaffold depends on `helm` to be installed as well, the appropriate thing to do would be to start FROM `gcr.io/cloud-builders/helm` but since its not an official builder yet what's the best approach here?