### PR TITLE
Only print helm arguments when debug is true

### DIFF
--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -44,5 +44,7 @@ fi
 echo "Running: helm repo update"
 helm repo update
 
-echo "Running: helm $@"
+if [ "$DEBUG" = true ]; then
+    echo "Running: helm $@"
+fi
 helm "$@"


### PR DESCRIPTION
By default, all arguments passed to helm are printed to stdout.  This is an issue when using `--set-string` to override a secret value.  The value is echoed to the logs of CI/CD.

This PR is meant to disable this behavior by default.  Only enabling it if running with an environment variable of `DEBUG=true`.