### PR TITLE
[dep] Add dep cloud builder

### DIFF
--- a/dep/Dockerfile.alpine
+++ b/dep/Dockerfile.alpine
@@ -1,0 +1,25 @@
+FROM golang:alpine
+
+# Install VCS tools to support "go get" commands and install gcc.
+RUN apk add --update --no-cache git mercurial subversion build-base
+
+# Install go dep *before* setting the blank GOPATH
+RUN go get -u github.com/golang/dep/cmd/dep
+ENV PATH=$GOPATH/bin:$PATH
+
+# We blank out the GOPATH because the base image sets it, and
+# if the user of this build step does *not* set it, we want to
+# explore other options for workspace derivation.
+ENV GOPATH=
+
+RUN mkdir /builder
+
+COPY go_workspace.go prepare_workspace.inc /builder/
+
+COPY dep.ash /builder/bin/
+RUN chmod +x /builder/bin/dep.ash
+ENV PATH=/builder/bin:$PATH
+
+RUN go build -o /builder/go_workspace /builder/go_workspace.go
+
+ENTRYPOINT ["dep.ash"]

--- a/dep/Dockerfile.debian
+++ b/dep/Dockerfile.debian
@@ -1,0 +1,25 @@
+FROM golang
+
+# Install VCS tools to support "go get" commands and install gcc.
+RUN apt-get update -qqy && apt-get install -qqy git mercurial subversion gcc
+
+# Install go dep *before* setting the blank GOPATH
+RUN go get -u github.com/golang/dep/cmd/dep
+ENV PATH=$GOPATH/bin:$PATH
+
+# We blank out the GOPATH because the base image sets it, and
+# if the user of this build step does *not* set it, we want to
+# explore other options for workspace derivation.
+ENV GOPATH=
+
+RUN mkdir /builder
+
+COPY go_workspace.go prepare_workspace.inc /builder/
+
+COPY dep.bash /builder/bin/
+RUN chmod +x /builder/bin/dep.bash
+ENV PATH=/builder/bin:$PATH
+
+RUN go build -o /builder/go_workspace /builder/go_workspace.go
+
+ENTRYPOINT ["dep.bash"]

--- a/dep/README.md
+++ b/dep/README.md
@@ -1,0 +1,22 @@
+# [go dep](https://github.com/golang/dep)
+
+The Dockerfile and scripts here help you use Google Cloud Builder to launch the **go dep** tool.
+
+You can choose between the **Alpine** and the **Debian** version.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud container builds submit . --config=cloudbuild.yaml
+
+## Example
+
+```yaml
+steps:
+# Make sure all dependencies are in the desired state
+- name: 'gcr.io/$PROJECT_ID/dep'
+  args: ['ensure', '-v']
+  env: ['PROJECT_ROOT=github.com/myorg/myproject']
+  id: 'dep'
+```

--- a/dep/cloudbuild.yaml
+++ b/dep/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud container builds submit . --config=cloudbuild.yaml
+
+steps:
+# Build the alpine and debian versions.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile.alpine', '--tag=gcr.io/$PROJECT_ID/dep:alpine', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile.debian', '--tag=gcr.io/$PROJECT_ID/dep:debian', '.']
+
+# The alpine version is our default.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/dep:alpine', 'gcr.io/$PROJECT_ID/dep']
+
+# Run version to make sure that everything is working properly.
+- name: 'gcr.io/$PROJECT_ID/dep'
+  args: ['version']
+
+images:
+- 'gcr.io/$PROJECT_ID/dep'
+- 'gcr.io/$PROJECT_ID/dep:alpine'
+- 'gcr.io/$PROJECT_ID/dep:debian'

--- a/dep/dep.ash
+++ b/dep/dep.ash
@@ -1,0 +1,19 @@
+#!/bin/ash
+#
+# Copyright 2016 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+. /builder/prepare_workspace.inc
+prepare_workspace || exit
+echo "Running: dep $@"
+dep "$@"

--- a/dep/dep.bash
+++ b/dep/dep.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2016 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+. /builder/prepare_workspace.inc
+prepare_workspace || exit
+echo "Running: dep $@"
+dep "$@"

--- a/dep/go_workspace.go
+++ b/dep/go_workspace.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Google, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+)
+
+func main() {
+	// This command looks for an import directive in a go source file in the
+	// current directory. https://golang.org/s/go14customimport has details of how
+	// import directives are specified.
+	pkg, err := build.ImportDir(".", build.ImportComment)
+	if err != nil {
+		fmt.Printf("Could not parse source in current directory: %v\n", err)
+		os.Exit(1)
+	}
+	if pkg.ImportComment == "" {
+		os.Exit(1)
+	}
+	fmt.Print(pkg.ImportComment)
+}

--- a/dep/prepare_workspace.inc
+++ b/dep/prepare_workspace.inc
@@ -1,0 +1,86 @@
+# Copyright 2016 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prepare_workspace() {
+    # We record the original working directory because some tools need to
+    # remember, and sometimes this function changes directory.
+    export WORKSPACE="$PWD"
+
+    # If $GOPATH is set, do nothing. The user has already set up the workspace.
+    if [[ "$GOPATH" ]]; then
+        # We allow relative paths here because of how the Container Builder
+        # service works. But, the Go tool does not allow relative paths. To
+        # accomodate the Go tool, we prepend the CWD to $GOPATH if $GOPATH is
+        # not absolute.
+        if [[ "${GOPATH:0:1}" != '/' ]]; then
+            export GOPATH="$PWD/$GOPATH"
+        fi
+        return 0
+    fi
+
+
+    # If there is a src directory, accept that as a GOPATH indicator.
+    if [[ -d src ]]; then
+        export GOPATH="$PWD"
+        return 0
+    fi
+
+    # Otherwise, we need to set up $GOPATH and map the source in somehow.
+
+
+    # If $PROJECT_ROOT is set, map the current directory into $GOPATH/src/$PROJECT_ROOT.
+    if [[ -z "$PROJECT_ROOT" ]]; then
+        # Nothing in the environment or directory structure gives a strong enough clue, let's inspect source.
+        PROJECT_ROOT="$(/builder/go_workspace)"
+        if [[ $? != 0 ]]; then
+            echo '
+Unable to determine the Go workspace structure.
+
+To determine the workspace structure, this tool checks the following, in order:
+1) Is $GOPATH set? Use that.
+2) Is there a ./src directory? Set GOPATH=$PWD.
+3) Is $PROJECT_ROOT set? Make a temporary workspace in GOPATH=./gopath, and link
+   the contents of the current directory into ./gopath/src/$PROJECT_ROOT/*.
+4) Does a .go file in the current directory have a comment like
+   // import "$PROJECT_ROOT"? Use the $PROJECT_ROOT found in the import
+   comment instead of a provided $PROJECT_ROOT environment variable.
+
+You are seeing this message because none of the checks succeeded.
+'
+            return 1
+        fi
+    fi
+
+    shadow_workspace="/go/src/$PROJECT_ROOT"
+    link_dir="$(dirname "$shadow_workspace")"
+
+    echo "Creating shadow workspace and symlinking source into \"$shadow_workspace\"."
+
+    mkdir -p "$link_dir" || return
+
+    # We provide the -T option so that another workspace symlink is not placed inside
+    # our workspace. If it fails, that's ok because it might be because a previous step
+    # already created the symlink.
+    ln  -s $PWD "$shadow_workspace" -T 2> /dev/null || stat "$shadow_workspace" 2> /dev/null || return
+
+    export GOPATH="/go"
+
+    # The tools that use this workspace preparation should be run from inside
+    # the shadow workspace. If they are run from their original locations,
+    # relative targets (eg. ".") will not work properly. Any files read or
+    # written from inside the shadow workspace will have the same affect as if
+    # they were read or written from the original directory, except that the new
+    # working directory will be properly couched in GOPATH.
+    cd "$shadow_workspace"
+}


### PR DESCRIPTION
This PR will add the dep cloud-builder as described in https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/60.
This cloud builder is based on the official go cloud-builder and provides a Debian and Alpine image.