### PR TITLE
add firebase cloudbuilder

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm i firebase-tools
+COPY firebase.bash .
+
+ENTRYPOINT ["/firebase.bash"]

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -1,0 +1,64 @@
+# firebase
+
+This build step invokes `firebase` commands that can be used in [Google Cloud Container Builder](cloud.google.com/container-builder/).
+
+Arguments passed to this builder will be passed to `firebase` directly,
+allowing callers to run [any firebase
+command](https://docs.docker.com/compose/reference/overview/).
+
+## Usage
+
+**Get the firebase token**
+
+This command will generate a new CI token that will be encrypted by the KMS to be used within the CLI
+
+```
+firebase login:ci
+```
+
+**Enable the KMS API**
+
+Click "setup" or "enable API" on https://console.cloud.google.com/security/kms 
+
+**Create the secret on GCP**
+
+This step will encrypt the token via KMS. Remember to replace `GENERATED_TOKEN` in the text
+
+```bash
+# create a keyring for cloudbuilder-related keys
+gcloud kms keyrings create cloudbuilder --location global
+
+# create a key for the firebase token
+gcloud kms keys create firebase-token --location global --keyring cloudbuilder --purpose encryption
+
+# create the encrypted token
+echo -n $TOKEN | gcloud kms encrypt \
+  --plaintext-file=- \
+  --ciphertext-file=- \
+  --location=global \
+  --keyring=cloudbuilder \
+  --key=firebase-token | base64
+```
+
+**Use the encrypted key**
+
+The encrypted key (output from previous command) can now simply be used within the cloudbuilder configuration file like so:
+
+> Note that you need to specify `[PROJECT_ID]` directly instead of using `$PROJECT_ID` within secrets
+
+```yaml
+secrets:
+- kmsKeyName: 'projects/[PROJECT_ID]/locations/global/keyRings/cloudbuilder/cryptoKeys/firebase-token'
+  secretEnv:
+    FIREBASE_TOKEN: '<YOUR_ENCRYPTED_TOKEN>'
+```
+
+**Add permission to the cloudbuilder**
+
+- Open GCP IAM menu
+- Find email ending with `@cloudbuild.gserviceaccount.com`
+- Add `Cloud KMS CryptoKey Decrypter` role to this account
+
+## Examples
+
+See examples in the `examples` subdirectory.

--- a/firebase/cloudbuild.yaml
+++ b/firebase/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase', '.']
+  secretEnv: ['FIREBASE_TOKEN']
+images:
+- 'gcr.io/$PROJECT_ID/firebase'

--- a/firebase/examples/cloudbuild.yaml
+++ b/firebase/examples/cloudbuild.yaml
@@ -1,0 +1,8 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/firebase'
+  args: ['list']
+  secretEnv: ['FIREBASE_TOKEN']
+secrets:
+- kmsKeyName: 'projects/[PROJECT_ID]/locations/global/keyRings/cloudbuilder/cryptoKeys/firebase-token'
+  secretEnv:
+    FIREBASE_TOKEN: '<ENCRYPTED_TOKEN>'

--- a/firebase/firebase.bash
+++ b/firebase/firebase.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# export path to the locally installed firebase tools
+export PATH=$PATH:/node_modules/firebase-tools/bin
+
+# run the original firebase
+firebase "$@" --token $FIREBASE_TOKEN


### PR DESCRIPTION
Hi there,

I just started using cloud builder as a CI&CD for Firebase. The builder installs `firebase-tools` locally via npm to avoid permission errors from node-gyp. The `firebase.bash` script then wraps every call to provide firebase CI token.

Cheers,
Peter