### PR TITLE
remote-builder: Fix default username in README

### DIFF
--- a/remote-builder/README.md
+++ b/remote-builder/README.md
@@ -68,7 +68,7 @@ build step in the `env` parameter:
 | Options       | Description   | Default |
 | ------------- | ------------- | ------- |
 | COMMAND | Command to run inside the remote workspace | None, must be set |
-| USERNAME  | Username to use when logging into the instance via SSH  | `cloud-user` |
+| USERNAME  | Username to use when logging into the instance via SSH  | `admin` |
 | REMOTE_WORKSPACE  | Location on remote host to use as workspace | `/home/${USERNAME}/workspace/` |
 | INSTANCE_NAME  | Name of the instance that is launched  | `builder-$UUID` |
 | ZONE  | Compute zone to launch the instance in | `us-central1-f` |


### PR DESCRIPTION
If I'm reading [1] correctly, it's "admin" rather than "cloud-user".

[1] https://github.com/GoogleCloudPlatform/cloud-builders-community/blob/cab7b7b2d290c1ec461e50c2723265a4c6f3b1a8/remote-builder/run-builder.sh#L11