### PR TITLE
Add a Flutter builder capable of building Android APKs and running unit test targets.

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -1,0 +1,56 @@
+# Flutter (https://flutter.io) Developement Environment for Linux
+# ===============================================================
+#
+# This environment passes all Linux Flutter Doctor checks and is sufficient
+# for building Android applications and running Flutter tests.
+#
+# To build iOS applications, a Mac development environment is necessary.
+#
+
+FROM debian:stretch
+MAINTAINER Chinmay Garde <chinmaygarde@google.com>
+
+# Install Dependencies.
+RUN apt update -y
+RUN apt install -y \
+  git \
+  wget \
+  curl \
+  unzip \
+  lib32stdc++6 \
+  libglu1-mesa \
+  default-jdk-headless
+
+# Install the Android SDK Dependency.
+ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+ENV ANDROID_TOOLS_ROOT="/opt/android_sdk"
+RUN mkdir -p "${ANDROID_TOOLS_ROOT}"
+ENV ANDROID_SDK_ARCHIVE="${ANDROID_TOOLS_ROOT}/archive"
+RUN wget -q "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
+RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "build-tools;28.0.0"
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platforms;android-28"
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platform-tools"
+RUN rm "${ANDROID_SDK_ARCHIVE}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/tools:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/tools/bin:${PATH}"
+
+# Install Flutter.
+ENV FLUTTER_ROOT="/opt/flutter"
+RUN git clone https://github.com/flutter/flutter "${FLUTTER_ROOT}"
+ENV PATH="${FLUTTER_ROOT}/bin:${PATH}"
+ENV ANDROID_HOME="${ANDROID_TOOLS_ROOT}"
+
+# Disable analytics and crash reporting on the builder.
+RUN flutter config  --no-analytics
+
+# Perform an artifact precache so that no extra assets need to be downloaded on demand.
+RUN flutter precache
+
+# Accept licenses.
+RUN yes "y" | flutter doctor --android-licenses
+
+# Perform a doctor run.
+RUN flutter doctor -v
+
+ENTRYPOINT [ "flutter" ]

--- a/flutter/README.md
+++ b/flutter/README.md
@@ -1,0 +1,28 @@
+# [Flutter](https://flutter.io) Cloud Builder Build Step
+========================================================
+
+This container builder provides the `[flutter]`(https://github.com/flutter/flutter) tool.
+
+## Building the Builder
+
+To build this builder, run the following command in this directory.
+
+```
+gcloud container builds submit . --config=cloudbuild.yaml
+```
+
+## Using the Flutter Build Step
+
+* To create a release APK of a Flutter application on Android.
+
+```
+- name: 'gcr.io/$PROJECT_ID/flutter'
+  args: [ 'build', 'apk', '--release' ]
+```
+
+* To run all Flutter unit tests.
+
+```
+ - name: 'gcr.io/$PROJECT_ID/flutter'
+   args: [ 'test' ]
+```

--- a/flutter/cloudbuild.yaml
+++ b/flutter/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'flutter'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/flutter', '.' ]
+
+images: [ 'gcr.io/$PROJECT_ID/flutter' ]
+
+# Examples:
+
+# Build an Android APK in release mode:
+# - name: 'gcr.io/$PROJECT_ID/flutter'
+#   args: [ 'build', 'apk', '--release' ]
+
+# To run tests.
+# - name: 'gcr.io/$PROJECT_ID/flutter'
+#   args: [ 'test' ]


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-builders/issues/292.

It is likely that the Flutter team should provide versioned containers in some registry. I have [filed a separate issue](https://github.com/flutter/flutter/issues/18534) for the same in the Flutter issue tracker.