### PR TITLE
Remove FIREBASE_TOKEN env from cloudbuild.yaml

### DIFF
--- a/firebase/cloudbuild.yaml
+++ b/firebase/cloudbuild.yaml
@@ -1,6 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase', '.']
-  secretEnv: ['FIREBASE_TOKEN']
 images:
 - 'gcr.io/$PROJECT_ID/firebase'


### PR DESCRIPTION
Building the image throws error: 
secretEnv "FIREBASE_TOKEN" is used without being defined'

Removing FIREBASE_TOKEN env reference fixes