### PR TITLE
Removed secretEnv option in firebase

### DIFF
--- a/firebase/cloudbuild.yaml
+++ b/firebase/cloudbuild.yaml
@@ -1,6 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase', '.']
-  secretEnv: ['FIREBASE_TOKEN']
 images:
 - 'gcr.io/$PROJECT_ID/firebase'


### PR DESCRIPTION
If secretEnv exists, build will fail.
Should fix #88 