### PR TITLE
Add a crane builder

### DIFF
--- a/crane/Dockerfile
+++ b/crane/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/cloud-builders/go as builder
+
+# Only allow static linking, so that crane can be used in a different
+# environment.
+ENV CGO_ENABLED=0
+RUN go get github.com/google/go-containerregistry/cmd/crane
+
+FROM launcher.gcr.io/google/ubuntu16_04
+
+COPY --from=builder /root/go/bin/crane /builder/bin/crane
+
+ENV PATH=/builder/bin/:$PATH
+
+ENTRYPOINT ["crane"]

--- a/crane/README.md
+++ b/crane/README.md
@@ -1,0 +1,25 @@
+# Skaffold (alpha)
+
+This Container Builder build step runs
+[`crane`](https://github.com/google/go-containerregistry/blob/master/cmd/crane/doc/crane.md).
+By default, `crane` has access to the Google Container Registry in which the
+build is running.
+
+## Example: Fetching the digest of the builder
+
+This example runs `crane digest` in a `cloudbuild.yaml`. This will print the
+Docker digest of a given image.
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/crane
+  args: ['digest', 'gcr.io/$PROJECT_ID/crane']
+```
+
+## Building this builder
+
+To build this builder and push the resulting image to the Container Registry
+in your project, run the following command in this directory:
+
+    $ gcloud builds submit . --config=cloudbuild.yaml
+

--- a/crane/cloudbuild.yaml
+++ b/crane/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/crane', '.']
+images: ['gcr.io/$PROJECT_ID/crane']

--- a/crane/cloudbuild.yaml
+++ b/crane/cloudbuild.yaml
@@ -1,4 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  id: Build
   args: ['build', '--tag=gcr.io/$PROJECT_ID/crane', '.']
+- name: gcr.io/$PROJECT_ID/crane
+  id: Test
+  args: ['digest', 'gcr.io/cloud-builders/docker']
 images: ['gcr.io/$PROJECT_ID/crane']


### PR DESCRIPTION
Sample usage of `crane` in a build: https://github.com/pdeslaur/skaffold-test/blob/skaffoldless-test/cloudbuild.yaml. This is useful for deploying to Kubernetes by digest.