### PR TITLE
Add Kustomize Custom Builder

### DIFF
--- a/kustomize/Dockerfile
+++ b/kustomize/Dockerfile
@@ -1,0 +1,21 @@
+FROM gcr.io/cloud-builders/gcloud
+
+ENV VERSION v1.0.6
+
+COPY kustomize.bash /builder/kustomize.bash
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.6/kustomize_1.0.6_linux_amd64 && \
+    mkdir /builder/kustomize && \
+    mv kustomize_1.0.6_linux_amd64 /builder/kustomize/kustomize && \
+    chmod +x /builder/kustomize/kustomize && \
+    chmod +x /builder/kustomize.bash && \
+    apt-get remove --purge -y curl && \
+    apt-get --purge -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/builder/kustomize:$PATH
+
+ENTRYPOINT ["/builder/kustomize.bash"]

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,74 @@
+# [Kustomize](https://github.com/kubernetes-sigs/kustomize)
+
+## Using this builder with Google Container Engine
+
+To use this builder, your
+[builder service account](https://cloud.google.com/cloud-build/docs/how-to/service-account-permissions)
+will need IAM permissions sufficient for the operations you want to perform. For
+typical read-only usage, the "Kubernetes Engine Viewer" role is sufficient. To
+deploy container images on a GKE cluster, the "Kubernetes Engine Developer" role
+is sufficient. Check the
+[GKE IAM page](https://cloud.google.com/container-engine/docs/iam-integration)
+for details.
+
+For most use, kubectl will need to be configured to point to a specific GKE
+cluster. You can configure the cluster by setting environment variables.
+
+    # Set region for regional GKE clusters or Zone for Zonal clusters
+    CLOUDSDK_COMPUTE_REGION=<your cluster's region>
+    or
+    CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+
+    # Name of GKE cluster
+    CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
+
+    # (Optional) Project of GKE Cluster, only if you want kustomize to authenticate
+    # to a GKE cluster in another project (requires IAM Service Accounts are properly setup)
+    GCLOUD_PROJECT=<destination cluster's GCP project>
+
+Setting the environment variables above will cause this step's entrypoint to
+first run a command to fetch cluster credentials as follows.
+
+    gcloud container clusters get-credentials --zone "$CLOUDSDK_COMPUTE_ZONE" "$CLOUDSDK_CONTAINER_CLUSTER"`
+
+Then, `kubectl` and consequently `kustomize` will have the configuration needed to talk to your GKE cluster.
+
+## Applying the build
+
+The default entrypoint will automatically apply your build via `kubectl apply -f -` if you set the env `APPLY=true`. Thus, you can run:
+
+```yaml
+- id: deploy
+  name: 'gcr.io/$PROJECT_ID/kustomize'
+  args:
+  - 'build'
+  - 'overlays/prod'
+  env:
+    - 'APPLY=true'
+    - 'CLOUDSDK_COMPUTE_ZONE=us-west1'
+    - 'CLOUDSDK_CONTAINER_CLUSTER=tf-k8s'
+    - 'GCLOUD_PROJECT=compound-dev'
+```
+
+To apply the build yourself, you can use a custom entrypoint, e.g.
+
+```yaml
+- id: deploy
+  name: 'gcr.io/$PROJECT_ID/kustomize'
+  entrypoint: bash
+  args:
+  - '-c'
+  - |
+    gcloud container clusters get-credentials --zone "$$CLOUDSDK_COMPUTE_ZONE" "$$CLOUDSDK_CONTAINER_CLUSTER"
+    kustomize build "overlays/prod" | kubectl apply -f -  
+  env:
+    - 'CLOUDSDK_COMPUTE_ZONE=us-west1'
+    - 'CLOUDSDK_CONTAINER_CLUSTER=tf-k8s'
+    - 'GCLOUD_PROJECT=compound-dev'
+```
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud builds submit . --config=cloudbuild.yaml

--- a/kustomize/cloudbuild.yaml
+++ b/kustomize/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/kustomize', '.']
+- # Verify kustomize has been built correctly
+  name: 'gcr.io/$PROJECT_ID/kustomize'
+  entrypoint: 'kustomize'
+  args: ['version']
+
+images: ['gcr.io/$PROJECT_ID/kustomize']

--- a/kustomize/examples/pods-list/cloudbuild.yaml
+++ b/kustomize/examples/pods-list/cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/kustomize'
+  args: ['build', 'overlays/prod']
+  env:
+  - 'APPLY=true'
+  - 'CLOUDSDK_COMPUTE_ZONE=us-east4-b'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=your-cluster'

--- a/kustomize/kustomize.bash
+++ b/kustomize/kustomize.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# If there is no current context, get one.
+if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
+    # This tries to read environment variables. If not set, it grabs from gcloud
+    cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+    region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+    zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+    project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+
+    function var_usage() {
+        cat <<EOF
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
+  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+EOF
+        exit 1
+    }
+
+    [[ -z "$cluster" ]] && var_usage
+    [ ! "$zone" -o "$region" ] && var_usage
+
+    if [ -n "$region" ]; then
+      echo "Running: gcloud config set container/use_v1_api_client false"
+      gcloud config set container/use_v1_api_client false
+      echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+    else
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+    fi
+fi
+
+if [ "$APPLY" = true ]; then
+  if [ "$DEBUG" = true ]; then
+    echo "Running: kustomize $@ | kubectl apply -f -"
+  fi
+
+  kustomize "$@" | kubectl apply -f -
+else
+  if [ "$DEBUG" = true ]; then
+    echo "Running: kustomize $@"
+  fi
+
+  kustomize "$@"
+fi


### PR DESCRIPTION
This patch adds a Kustomize cloud builder. The builder (largely based off of helm) easily allows users of [kustomize](https://github.com/kubernetes-sigs/kustomize) to build and apply kustomize templates in Cloud Build. We've opted to add an entrypoint script that allows the user to apply the kustomize script when he/she sets the env var `APPLY=true`. We use the same variables for getting gcloud settings as Helm and gcloud. Additionally, we've added instructions for using non-standard kustomize runs.