### PR TITLE
Usage of mvn cloud builder instead of a custom mvn builder image. Other readme updates.

### DIFF
--- a/jfrog/README.md
+++ b/jfrog/README.md
@@ -1,35 +1,35 @@
 ## Google Cloud Build integration with JFrog Artifactory
 
-There are times when you’ll want to use Google Cloud Build with a private repository such as JFrog Artifactory, the universal artifact manger. Here are few use cases and there will certainly be more -
+Here are few use cases of this integration -
 * Containerize an existing application that’s stored in a private repository?
 * Containerize an application that relies on both private and public dependencies?
 * Improve build and deployment time by caching dependencies?
+* Ensure that the third-party libraries come from trusted sources to make the pipeline more robust.
 
 This readme walks through the steps required to configure Cloud Build to work with JFrog Artifactory.
 
 ### Pre-req: Create a cloud builder image that includes JFrog CLI
 
-The top level folder includes cloudbuild.yaml file that can be used to build a JFrog cloud-build image. JFrog CLI is package agnostic that means that the same version of CLI can be used to build maven, gradle, npm, Go, Conan, docker projects. 
+The top level folder includes cloudbuild.yaml file that can be used to build a JFrog cloud-build image. JFrog CLI is package agnostic that means that the same version of CLI can be used to build maven, gradle, npm, Go, Conan, docker projects. We do recommend to build an image for each package type.
 
 **Steps to build JFrog builder image**
 
 `gcloud builds submit --config=cloudbuild.yaml .`
 
-The current version of cloudbuild.yaml makes the base image configurable so that it's easy to generate a builder for a specific package type that also includes JFrog CLI.
-
+The base image is configurable in the current version of cloudbuild.yaml. In this example, one is being built to support mvn packages -
 
 ```steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/${PROJECT_ID}/mvn:3.3.9-jdk-8'
+  - '--build-arg=BASE_IMAGE=gcr.io/cloud-builders/mvn:3.3.9-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/java/jfrog:1.17.0'
   - '.'
   wait_for: ['-']
   
 ```
 
-Once the builder is created, it can be used to build maven, gradle, npm, Go, docker based projects. The steps to containerize a Java application using Google Cloud Build with JFrog Artifactory as a source of truth is as follows:
+The steps to containerize a Java application using Google Cloud Build with JFrog Artifactory as a source of truth is as follows:
 
 
 #### Step 1: Security

--- a/jfrog/cloudbuild.yaml
+++ b/jfrog/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/${PROJECT_ID}/mvn:3.3.9-jdk-8'  
+  - '--build-arg=BASE_IMAGE=gcr.io/cloud-builders/mvn:3.3.9-jdk-8'  
   - '--tag=gcr.io/$PROJECT_ID/java/jfrog:1.17.1'
   - '.'
   wait_for: ['-']
@@ -19,32 +19,6 @@ steps:
   - 'gcr.io/$PROJECT_ID/java/jfrog:1.17.1'
   - 'gcr.io/$PROJECT_ID/java/jfrog'
 
-# Configure JFrog CLI to point to JFrog Artifactory
-- name: 'gcr.io/$PROJECT_ID/java/jfrog'
-  entrypoint: 'bash'
-  args: ['-c', 'jfrog rt c rt-mvn-repo --url=https://[ARTIFACTORY-URL]/artifactory --user=[ARTIFACTORY-USER] --password=$$APIKEY']
-  secretEnv: ['APIKEY']
-  dir: 'examples/maven-example'
-
-# Build a sample maven project
-- name: 'gcr.io/$PROJECT_ID/java/jfrog'
-  args: ['rt', 'mvn', "clean install", 'config.yaml', '--build-name=mybuild', '--build-number=$BUILD_ID']
-  dir: 'examples/maven-example'
-
-# Containerize java app
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'build'
-  - '--tag=gcr.io/$PROJECT_ID/java-app:${BUILD_ID}'
-  - '.'
-  dir: 'examples/maven-example'
-
-secrets:
-- kmsKeyName: projects/soldev-ci/locations/global/keyRings/[KEYRING-NAME]/cryptoKeys/[KEY-NAME]
-  secretEnv:
-    APIKEY: [ENCRYPTED_API_KEY] 
-
 images:
-- 'gcr.io/$PROJECT_ID/java-app:${BUILD_ID}'
 - 'gcr.io/$PROJECT_ID/java/jfrog:1.17.1'
 - 'gcr.io/$PROJECT_ID/java/jfrog'

--- a/jfrog/examples/cloudbuild.yaml
+++ b/jfrog/examples/cloudbuild.yaml
@@ -8,7 +8,7 @@
 steps:
 
 # Configure JFrog CLI to point to JFrog Artifactory
-- name: 'gcr.io/$PROJECT_ID/java/jfrog'
+- name: 'jfrog-docker-reg2.bintray.io/google-cloud-builder/java/jfrog:0.1'
   entrypoint: 'bash'
   args: ['-c', 'jfrog rt c rt-mvn-repo --url=https://[ARTIFACTORY-URL]/artifactory --user=[ARTIFACTORY-USER] --password=$$APIKEY']
   secretEnv: ['APIKEY']


### PR DESCRIPTION
1. Usage of mvn cloud builder image
2. readme updates
3. Removed the extra steps from the parent cloudbuild.yaml