### PR TITLE
chore: add angular cli cloud builders

### DIFF
--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm install -g @angular/cli@latest --unsafe-perms
+
+ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_next
+++ b/ng/Dockerfile_next
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm install -g @angular/cli@next --unsafe-perms
+
+ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v1
+++ b/ng/Dockerfile_v1
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm install -g @angular/cli@1.* --unsafe-perms
+
+ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v6
+++ b/ng/Dockerfile_v6
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm install -g @angular/cli@6.* --unsafe-perms
+
+ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v7
+++ b/ng/Dockerfile_v7
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/npm
+
+RUN npm install -g @angular/cli@7.* --unsafe-perms
+
+ENTRYPOINT ["ng"]

--- a/ng/README.md
+++ b/ng/README.md
@@ -1,0 +1,42 @@
+# The ng (Angular CLI) Cloud Builders
+
+This build step invokes the `ng` command provided by the [Angular CLI](https://github.com/angular/angular-cli) distributed in [Google Cloud Build](cloud.google.com/cloud-build/).
+
+Arguments passed to this builder will be passed to the `ng` command directly,
+allowing callers to run [any `ng`
+command](https://github.com/angular/angular-cli/wiki#additional-commands/).
+
+## Available builders
+
+For convenience, we have included different versions of the Angular CLI:
+- `gcr.io/cloud-builders/ng:v1`: provides the v1.* legacy branch
+- `gcr.io/cloud-builders/ng:v6`: provides the v6.* branch
+- `gcr.io/cloud-builders/ng:latest`: provides the latest stable branch
+- `gcr.io/cloud-builders/ng`: same as latest
+- `gcr.io/cloud-builders/ng:next`: provides the next unstable branch
+
+## How to use?
+
+In order to use call one of these builder, simply invoke the builder (and version), for instance:
+
+```
+steps:
+- name: 'gcr.io/$PROJECT_ID/ng:next'
+  args: ['build', '--prod']
+```
+
+Or, if you are maintaining a legacy Angular project:
+```
+steps:
+- name: 'gcr.io/$PROJECT_ID/ng:v1'
+  args: ['test', '--sourcemap=false']
+```
+
+See the `examples` folder for a complete example.
+
+
+## Building these builders
+
+To build these builders, run the following command in this directory:
+
+    $ gcloud builds submit . --config=cloudbuild.yaml

--- a/ng/cloudbuild.yaml
+++ b/ng/cloudbuild.yaml
@@ -1,0 +1,20 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v1', '-f', 'Dockerfile_v1', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v6', '-f', 'Dockerfile_v6', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v7', '-f', 'Dockerfile_v7', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:latest', '-f', 'Dockerfile', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng', '-f', 'Dockerfile', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:next', '-f', 'Dockerfile_next', '.' ]
+images:
+  - 'gcr.io/$PROJECT_ID/ng:v1'
+  - 'gcr.io/$PROJECT_ID/ng:v6'
+  - 'gcr.io/$PROJECT_ID/ng:v7'
+  - 'gcr.io/$PROJECT_ID/ng:latest'
+  - 'gcr.io/$PROJECT_ID/ng'
+  - 'gcr.io/$PROJECT_ID/ng:next'

--- a/ng/examples/README.md
+++ b/ng/examples/README.md
@@ -1,0 +1,7 @@
+# ng cloud builders example
+
+This `cloudbuild.yaml` invokes all available versions of the Angular CLI builders. To try the example, run the following command in this directory.
+
+    $ gcloud builds submit . --config=cloudbuild.yaml
+
+You should be able to see the output of each version of the Angular CLI.

--- a/ng/examples/cloudbuild.yaml
+++ b/ng/examples/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/ng:v1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/ng:v6'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/ng'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/ng:next'
+  args: ['--version']


### PR DESCRIPTION
For convenience, we have included different versions of the Angular CLI:
- `gcr.io/angular-cloud-builder/ng:v1`: provides the `v1.*` legacy branch
- `gcr.io/angular-cloud-builder/ng:v6`: provides the `v6.*` branch
- `gcr.io/angular-cloud-builder/ng:latest`: provides the latest stable branch
- `gcr.io/angular-cloud-builder/ng`: same as latest
- `gcr.io/angular-cloud-builder/ng:next`: provides the next unstable branch