### PR TITLE
build(android): fix missing dir

### DIFF
--- a/android/licenses/.gitignore
+++ b/android/licenses/.gitignore
@@ -1,0 +1,3 @@
+# This directory just needs to be present
+# for the gsutil step in cloudbuild.yaml to work
+!.gitignore


### PR DESCRIPTION
When following the instructions I got the not so obvious error message:
```
Starting Step #0 - "copy-licenses"
Step #0 - "copy-licenses": Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #0 - "copy-licenses": CommandException: arg (licenses) does not name a directory, bucket, or bucket subdir
```
So the `gsutil` step of `cloudbuild.yaml` assumes that the `licenses` directory is present. This is one way to make it work for now I think.