### PR TITLE
use build args to source helm version

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,14 +1,14 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV VERSION v2.9.1
-
 COPY helm.bash /builder/helm.bash
+
+ARG HELM_VERSION=v2.9.1
 
 RUN chmod +x /builder/helm.bash && \
   mkdir -p /builder/helm && \
   apt-get update && \
   apt-get install -y curl && \
-  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
   tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm && \
   rm helm.tar.gz && \
   apt-get --purge -y autoremove && \

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.10.0', '.']
 
 images: ['gcr.io/$PROJECT_ID/helm']


### PR DESCRIPTION
Allows helm to be updated via docker build-arg, this will allow updates of the helm version without modifying the dockerfile. 

👀 @rimusz