### PR TITLE
Improve Tillerless Helm and add RBAC setup to readme.

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV VERSION v2.9.1
+ARG HELM_VERSION=v2.10.0
 
 COPY helm.bash /builder/helm.bash
 
@@ -8,7 +8,7 @@ RUN chmod +x /builder/helm.bash && \
   mkdir -p /builder/helm && \
   apt-get update && \
   apt-get install -y curl && \
-  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
   tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm && \
   rm helm.tar.gz && \
   apt-get --purge -y autoremove && \

--- a/helm/README.md
+++ b/helm/README.md
@@ -37,21 +37,54 @@ Then, `kubectl` and consequently `helm` will have the configuration needed to ta
 
 To build this builder, run the following command in this directory.
 
-    $ gcloud builds submit . --config=cloudbuild.yaml
+    gcloud builds submit . --config=cloudbuild.yaml
+
+You can also build this builder setting `Helm` version via in `cloudbuild.yaml`, no need to do that in `Dockerfile` anymore.
+
+    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.10.0', '.']
 
 ## Using Helm
 
 This builder supports two install options of Helm:
-* The default one when the `tiller` gets installed into your GKE cluster (oh all those `tiller` security issues)
-* `Tillerless Helm`, I wrote a [blog post](https://rimusz.net/tillerless-helm/) of using Helm local [tiller plugin](https://github.com/rimusz/helm-tiller) which solves all those `tiller` security issues, as `tiller` runs outside the GKE cluster.
+* The default one when the `tiller` gets installed into your GKE cluster.
+* Secure `Tillerless Helm` where `tiller` runs outside the GKE cluster.
 
-Check the [examples](examples) folder for examples of using both Helm install options in `Cloud Build` pipelines.
+Check the [examples](examples) folder for examples of using Helm in `Cloud Build` pipelines.
 
-You can test e.g. installing a chart via `Tillerless Helm`, running the following command.
 **Note:** Do not forget to update `zone` and GKE `cluster` settings in the `cloudbuild.yaml` files.
 
-    $ gcloud builds submit . --config=examples/chart-install-tillerless/cloudbuild.yaml
+### Default Helm + Tiller setup
+
+The default one when the `tiller` gets installed into your GKE cluster (oh all those `tiller` security issues).
+
+You can test e.g. installing a chart via `Helm`, running the following command.
+
+    gcloud builds submit . --config=examples/chart-install/cloudbuild.yaml
+
+And to list Helm releases.
+
+    $ gcloud builds submit . --config=examples/releases-list/cloudbuild.yaml
+
+
+### Tillerless Helm setup
+
+`Tillerless Helm` which solves all those `tiller` security issues, as `tiller` runs outside the GKE cluster.
+I wrote a [blog post](https://rimusz.net/tillerless-helm/) how to use Helm local [tiller plugin](https://github.com/rimusz/helm-tiller).
+
+You can test e.g. installing a chart via `Tillerless Helm`, running the following command.
+
+    gcloud builds submit . --config=examples/chart-install-tillerless/cloudbuild.yaml
 
 And to list Helm releases.
 
     $ gcloud builds submit . --config=examples/releases-list-tillerless/cloudbuild.yaml
+
+**Note:** Also if your GKE cluster has `RBAC` enabled, you must grant Cloud Build Service Account `cluster-admin` role (or make it more specific for your use case), but for some reason Cloud Build uses Cloud Build Service Account `uniqueId` to authenticate to the GKE cluster instead of it's email address.
+
+Below is example how to set it up with `uniqueId`.
+
+    # Get Cloud Build Service Account uniqueId
+    user=$(gcloud iam service-accounts describe your_project_id@cloudbuild.gserviceaccount.com | grep -o 'uniqueId.*' | awk -v FS="('|')" '{print $2}')
+
+    # Grant Cloud Build Service Account `cluster-admin` role
+    kubectl create clusterrolebinding cluster-admin-$user --clusterrole cluster-admin --user $user

--- a/helm/README.md
+++ b/helm/README.md
@@ -3,12 +3,12 @@
 ## Using this builder with Google Container Engine
 
 To use this builder, your
-[builder service account](https://cloud.google.com/cloud-build/docs/how-to/service-account-permissions)
+[Cloud Build Service Account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions)
 will need IAM permissions sufficient for the operations you want to perform. For
 typical read-only usage, the "Kubernetes Engine Viewer" role is sufficient. To
 deploy container images on a GKE cluster, the "Kubernetes Engine Developer" role
 is sufficient. Check the
-[GKE IAM page](https://cloud.google.com/container-engine/docs/iam-integration)
+[GKE IAM page](https://cloud.google.com/kubernetes-engine/docs/concepts/access-control)
 for details.
 
 For most use, kubectl will need to be configured to point to a specific GKE

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.10.0', '.']
 
 images: ['gcr.io/$PROJECT_ID/helm']

--- a/helm/examples/chart-install-tillerless/cloudbuild.yaml
+++ b/helm/examples/chart-install-tillerless/cloudbuild.yaml
@@ -1,7 +1,8 @@
 steps:
 - name: 'gcr.io/$PROJECT_ID/helm'
-  args: ['test', '--', 'helm', 'install', 'stable/filebeat','--name', 'filebeat', '--namespace', 'filebeat', '--set', 'rbac.create=false']
+  args: ['upgrade', '--install', 'filebeat', '--namespace', 'filebeat', 'stable/filebeat']
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-c'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=kube-cluster1'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=your_gke_cluster'
   - 'TILLERLESS=true'
+  - 'TILLER_NAMESPACE=test'

--- a/helm/examples/chart-install/cloudbuild.yaml
+++ b/helm/examples/chart-install/cloudbuild.yaml
@@ -2,5 +2,5 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/helm'
   args: ['install', 'stable/keel', '--name', 'keel', '--namespace', 'keel']
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-east4-b'
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-c'
   - 'CLOUDSDK_CONTAINER_CLUSTER=your-cluster'

--- a/helm/examples/releases-list-tillerless/cloudbuild.yaml
+++ b/helm/examples/releases-list-tillerless/cloudbuild.yaml
@@ -1,7 +1,8 @@
 steps:
 - name: 'gcr.io/$PROJECT_ID/helm'
-  args: ['test', '--', 'helm', 'list']
+  args: ['list']
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-east4-b'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=your-cluster'
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-c'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=your_gke_cluster'
   - 'TILLERLESS=true'
+  - 'TILLER_NAMESPACE=test'

--- a/helm/examples/releases-list/cloudbuild.yaml
+++ b/helm/examples/releases-list/cloudbuild.yaml
@@ -2,5 +2,5 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/helm'
   args: ['list']
   env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-east4-b'
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-c'
   - 'CLOUDSDK_CONTAINER_CLUSTER=your-cluster'

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -44,15 +44,20 @@ fi
 echo "Running: helm repo update"
 helm repo update
 
-# check if Tillerless value 'TILLERLESS=true' is provided then install the plugin
-# and run "helm tiller run $@"
+# check if Tillerless value 'TILLERLESS=true' is provided then install and start the plugin
 if [ "$TILLERLESS" = true ]; then
   echo "Installing Tillerless plugin"
   helm plugin install https://github.com/rimusz/helm-tiller
+  echo "Starting Tillerless plugin"
+  helm tiller start-ci "$TILLER_NAMESPACE"
+  echo
+  export HELM_HOST=localhost:44134
   if [ "$DEBUG" = true ]; then
-      echo "Running: helm tiller run $@"
+      echo "Running: helm $@"
   fi
-  helm tiller run "$@"
+  helm "$@"
+  sleep 2
+  helm tiller stop
 else
   if [ "$DEBUG" = true ]; then
       echo "Running: helm $@"

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -56,7 +56,6 @@ if [ "$TILLERLESS" = true ]; then
       echo "Running: helm $@"
   fi
   helm "$@"
-  sleep 2
   helm tiller stop
 else
   if [ "$DEBUG" = true ]; then


### PR DESCRIPTION
Improve Tillerless Helm use case and add RBAC setup example to helm readme.
Incorporate #110, which upgrades Helm to v2.10.0 and allows helm to be updated via docker build-arg, this will allow updates of the helm version without modifying the dockerfile.