### PR TITLE
[Android Builder] Check executable before script

### DIFF
--- a/android/installed-package-list.sh
+++ b/android/installed-package-list.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-sdkmanager --list --verbose 2>/dev/null | sed -e '/Installed packages:/d' | sed -n '/Available Packages/!p;//q' | grep '^[a-z].*' | sed -e '/tools/d' >packages.txt
+if which sdkmanager >/dev/null; then
+    sdkmanager --list --verbose 2>/dev/null | sed -e '/Installed packages:/d' | sed -n '/Available Packages/!p;//q' | grep '^[a-z].*' | sed -e '/tools/d' >packages.txt
+else
+    echo "Couldn't find sdkmanager in your PATH"
+    exit 1
+fi


### PR DESCRIPTION
Hi, first of all, thanks for making Android builder for Cloud Build.

While my team were testing this builder, we found that the list package script just failed silently, and thus want to add a warning in this PR.