### PR TITLE
Updated Dockerfile and firebase.bash

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/cloud-builders/npm
 
-RUN npm i firebase-tools
+RUN npm install -g firebase-tools
 COPY firebase.bash .
+RUN chmod +x /firebase.bash
 
 ENTRYPOINT ["/firebase.bash"]

--- a/firebase/firebase.bash
+++ b/firebase/firebase.bash
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# export path to the locally installed firebase tools
-export PATH=$PATH:/node_modules/firebase-tools/bin
-
-# run the original firebase
+# # run a supplied firebase command with token 'FIREBASE_TOKEN'
 firebase "$@" --token $FIREBASE_TOKEN


### PR DESCRIPTION
After the latest release of Firebase tools (`6.0.0`) the installation command `npm i firebase-tools` in the Dockerfile did not work in conjunction with the `export PATH=$PATH:/node_modules/firebase-tools/bin` in the `firebase.bash`. Changing the installation command to `npm install -g firebase-tools` and removing the `export PATH` part in `firebase.bash` seems it does the job.