### PR TITLE
Add npm puppeteer container

### DIFF
--- a/npm-puppeteer/Dockerfile
+++ b/npm-puppeteer/Dockerfile
@@ -1,0 +1,24 @@
+ARG NODE_VERSION
+FROM node:$NODE_VERSION-alpine
+
+# Installs latest Chromium (64) package.
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      chromium@edge \
+      nss@edge \
+      git
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV CI true
+
+# Puppeteer v1.4.0 works with Chromium 68.
+RUN npm install puppeteer@1.9.0
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["dumb-init", "--", "npm"]

--- a/npm-puppeteer/README.md
+++ b/npm-puppeteer/README.md
@@ -1,0 +1,13 @@
+# Tool builder: `gcr.io/$PROJECT_ID/npm-puppeteer`
+
+This Container Builder build step runs the `npm` tool but with the necessary dependencies for [puppeteer](https://github.com/GoogleChrome/puppeteer).
+
+It uses the small alpine-node base.
+
+**Note:** This is based on [yarn-puppeteer](../yarn-puppeteer/README.md), but using npm instead.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud builds submit . --config=cloudbuild.yaml

--- a/npm-puppeteer/cloudbuild.yaml
+++ b/npm-puppeteer/cloudbuild.yaml
@@ -1,0 +1,67 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+#
+
+steps:
+# Build all supported versions.
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=6.14.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:node-6.14.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=8.11.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:node-8.11.1'
+  # 8.11.1 is tagged :latest
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:latest'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=9.11.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:node-9.11.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=10.0.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:node-10.0.0'
+  # 10.0.0 is tagged :current
+  - '--tag=gcr.io/$PROJECT_ID/npm-puppeteer:current'
+  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm-puppeteer'
+  - '.'
+
+# Print for each version
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:node-6.14.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:node-8.11.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:node-9.11.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:node-10.0.0'
+  args: ['--version']
+
+# Test the examples with :latest
+
+# hello_world
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:latest'
+  args: ['install']
+  dir: 'examples/hello_world'
+- name: 'gcr.io/$PROJECT_ID/npm-puppeteer:latest'
+  args: ['test']
+  dir: 'examples/hello_world'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/hello_world'
+
+images:
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:latest'
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:current'
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:node-6.14.1'
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:node-8.11.1'
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:node-9.11.1'
+- 'gcr.io/$PROJECT_ID/npm-puppeteer:node-10.0.0'
+- 'gcr.io/$PROJECT_ID/nodejs/npm-puppeteer'


### PR DESCRIPTION
Adding a container for [puppeteer](https://github.com/GoogleChrome/puppeteer/) and npm.

This is based on the existing container `yarn-puppeteer` but using npm instead.

I also bumped puppeteer version to the latest one (1.9.0).