### PR TITLE
Use puppeteer 1.4.0

### DIFF
--- a/yarn-puppeteer/Dockerfile
+++ b/yarn-puppeteer/Dockerfile
@@ -1,22 +1,24 @@
 ARG NODE_VERSION
 FROM node:$NODE_VERSION-alpine
 
-# Installs latest Chromium (64) package.
+# Installs latest Chromium (68) package.
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
     apk add --no-cache \
       chromium@edge \
       nss@edge \
-      git
+      git \
+      freetype@edge \
+      harfbuzz@edge
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV JEST_PUPPETEER_CONFIG jest-puppeteer.config.js
 ENV CI true
 
-# Puppeteer v0.13.0 works with Chromium 64.
-RUN yarn add puppeteer@0.13.0
+# Puppeteer v1.4.0 works with Chromium 68.
+RUN yarn add puppeteer@1.4.0
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init


### PR DESCRIPTION
and add chromium 68 missing symbols fix: https://github.com/GoogleChrome/puppeteer/issues/3019#issuecomment-417227105
