### PR TITLE
Install firebase globally to prevent path errors

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/npm
 
-RUN npm i firebase-tools
+RUN npm i -g firebase-tools
 COPY firebase.bash .
 
 ENTRYPOINT ["/firebase.bash"]

--- a/firebase/firebase.bash
+++ b/firebase/firebase.bash
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# export path to the locally installed firebase tools
-export PATH=$PATH:/node_modules/firebase-tools/bin
-
 # run the original firebase
 firebase "$@" --token $FIREBASE_TOKEN


### PR DESCRIPTION
I kept encountering a command line error when attempting to use firebase from the currently configured `$PATH`, so I changed it to be globally installed, and everything works fine now. The error was: 

```Step #0: /firebase.bash: line 7: firebase: command not found```