### PR TITLE
Add CFT (Cloud Foundation Toolkit) Builder

### DIFF
--- a/cft/Dockerfile
+++ b/cft/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update && apt-get -y install make \
     && pip install setuptools \
     && git clone https://github.com/GoogleCloudPlatform/deploymentmanager-samples \
     && cd deploymentmanager-samples/ \
-    && git checkout cloud-foundation \
     && cd community/cloud-foundation \
     && make prerequisites \
     && make build \

--- a/cft/Dockerfile
+++ b/cft/Dockerfile
@@ -1,0 +1,15 @@
+FROM gcr.io/cloud-builders/gcloud
+
+RUN apt-get update && apt-get -y install make \
+    && pip install setuptools \
+    && git clone https://github.com/GoogleCloudPlatform/deploymentmanager-samples \
+    && cd deploymentmanager-samples/ \
+    && git checkout cloud-foundation \
+    && cd community/cloud-foundation \
+    && make prerequisites \
+    && make build \
+    && make install \
+    && cd / \
+    && rm -rf /deploymentmanager-samples
+
+ENTRYPOINT ["/usr/local/bin/cft"]

--- a/cft/README.md
+++ b/cft/README.md
@@ -1,0 +1,13 @@
+# CFT (Cloud Foundation Toolkit)
+
+This build step invokes `cft` commands in [Google Cloud Build](https://cloud.google.com/cloud-build).
+
+Arguments passed to this builder will be passed to `cft` directly, allowing
+callers to run [any CFT
+command](https://github.com/GoogleCloudPlatform/deploymentmanager-samples/blob/cloud-foundation/community/cloud-foundation/docs/userguide.md#cli-usage).
+
+See examples in the `examples` subdirectory.
+
+## Status
+
+This is unsupported demo-ware. Use at your own risk!

--- a/cft/cloudbuild.yaml
+++ b/cft/cloudbuild.yaml
@@ -1,0 +1,15 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/cft:${_CFT_VERSION}',
+        '-t', 'gcr.io/$PROJECT_ID/cft',
+        '--build-arg', 'CFT_VERSION=${_CFT_VERSION}',
+        '.']
+substitutions:
+  _CFT_VERSION: 0.0.2
+
+images:
+- 'gcr.io/$PROJECT_ID/cft:latest'
+- 'gcr.io/$PROJECT_ID/cft:$_CFT_VERSION'

--- a/cft/examples/README.md
+++ b/cft/examples/README.md
@@ -1,0 +1,17 @@
+# CFT GCE Build
+
+This build creates a GCE instance by executing `cft` command.
+
+Note: This example assumes that you have built the `cft` build step and pushed it to
+`gcr.io/$PROJECT_ID/cft`.
+
+## Executing the CFT Builder
+
+To run this example, make sure you have assigned the [Deployment Manager
+Editor](https://cloud.google.com/iam/docs/understanding-roles#deployment_manager_roles)
+role to [your Cloud Build service
+account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions),
+and run:
+```
+    gcloud builds submit . --config=cloudbuild.yaml
+```

--- a/cft/examples/README.md
+++ b/cft/examples/README.md
@@ -15,3 +15,8 @@ and run:
 ```
     gcloud builds submit . --config=cloudbuild.yaml
 ```
+
+To clean up the resources, run the following:
+```
+    gcloud builds submit . --config=cloudbuild-delete.yaml
+```

--- a/cft/examples/README.md
+++ b/cft/examples/README.md
@@ -6,17 +6,22 @@ Note: This example assumes that you have built the `cft` build step and pushed i
 `gcr.io/$PROJECT_ID/cft`.
 
 ## Executing the CFT Builder
-
-To run this example, make sure you have assigned the [Deployment Manager
+Make sure you have assigned the [Deployment Manager
 Editor](https://cloud.google.com/iam/docs/understanding-roles#deployment_manager_roles)
-role to [your Cloud Build service
-account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions),
-and run:
-```
-    gcloud builds submit . --config=cloudbuild.yaml
+role to the [Cloud Build service
+account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions).
+```bash
+export PROJECT=$(gcloud info --format='value(config.project)')
+export MEMBER=$(gcloud projects describe $PROJECT --format 'value(projectNumber)')@cloudbuild.gserviceaccount.com
+gcloud projects add-iam-policy-binding $PROJECT --member=serviceAccount:$MEMBER --role='roles/deploymentmanager.editor'
 ```
 
-To clean up the resources, run the following:
+To create the resource using CFT, run the following:
+```bash
+gcloud builds submit . --config=cloudbuild.yaml
 ```
-    gcloud builds submit . --config=cloudbuild-delete.yaml
+
+To clean up the resource using CFT, run the following:
+```bash
+gcloud builds submit . --config=cloudbuild-delete.yaml
 ```

--- a/cft/examples/cloudbuild-delete.yaml
+++ b/cft/examples/cloudbuild-delete.yaml
@@ -1,0 +1,10 @@
+# Perform a cft command execution based on the `instance.yaml` configuration. This template
+# build deletes a GCE image.
+#
+# See README.md for invocation instructions.
+steps:
+- name: 'gcr.io/$PROJECT_ID/cft'
+  args:
+  - --project=$PROJECT_ID
+  - delete
+  - instance.yaml

--- a/cft/examples/cloudbuild.yaml
+++ b/cft/examples/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/cft'
+  args:
+  - --project=$PROJECT_ID
+  - apply
+  - instance.yaml

--- a/cft/examples/cloudbuild.yaml
+++ b/cft/examples/cloudbuild.yaml
@@ -1,3 +1,7 @@
+# Perform a cft command execution based on the `instance.yaml` configuration. This template
+# build creates a GCE image.
+#
+# See README.md for invocation instructions.
 steps:
 - name: 'gcr.io/$PROJECT_ID/cft'
   args:

--- a/cft/examples/instance.yaml
+++ b/cft/examples/instance.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: cft-instance-vm
+  type: compute.v1.instance
+  properties:
+    zone: us-central1-f
+    machineType: zones/us-central1-f/machineTypes/f1-micro
+    disks:
+    - deviceName: boot
+      type: PERSISTENT
+      boot: true
+      autoDelete: true
+      initializeParams:
+        sourceImage: projects/debian-cloud/global/images/family/debian-9
+    networkInterfaces:
+    - network: global/networks/default
+      accessConfigs:
+      - name: External NAT
+        type: ONE_TO_ONE_NAT


### PR DESCRIPTION
This is to add a Cloud Builder for [CFT (Cloud Foundation Toolkit)](https://github.com/GoogleCloudPlatform/deploymentmanager-samples/blob/cloud-foundation/community/cloud-foundation/docs/userguide.md).