### PR TITLE
 Add nix-build builder

### DIFF
--- a/nix-build/Dockerfile
+++ b/nix-build/Dockerfile
@@ -1,0 +1,6 @@
+FROM nixos/nix
+
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+RUN nix-channel --update
+
+ENTRYPOINT ["nix-build"]

--- a/nix-build/README.md
+++ b/nix-build/README.md
@@ -1,0 +1,16 @@
+# nix-build
+
+This build step uses the [Nix build
+system](https://nixos.org/nix/manual/#sec-nix-build), which
+executes builds described in the Nix config language.
+
+As an example, the build config executes a script that produces a
+layered Docker image based on [these
+instructions](https://grahamc.com/blog/nix-and-layered-docker-images).
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud builds submit . --config=cloudbuild.yaml
+

--- a/nix-build/cloudbuild.yaml
+++ b/nix-build/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
  
 # Use the image to build the Nix build cript.
 - name: gcr.io/$PROJECT_ID/nix-build
-  args: ['default.nix', '--argstr', 'name', 'gcr.io/$PROJECT_ID/nix-built-mysql']
+  args: ['default.nix', '--argstr', 'imageName', 'gcr.io/$PROJECT_ID/nix-built-mysql']
   volumes:
   - name: nix-store
     path: /nix/

--- a/nix-build/cloudbuild.yaml
+++ b/nix-build/cloudbuild.yaml
@@ -1,0 +1,22 @@
+steps:
+# Build the nix-build builder image.
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/nix-build', '.']
+ 
+# Use the image to build the Nix build cript.
+- name: gcr.io/$PROJECT_ID/nix-build
+  args: ['default.nix', '--argstr', 'name', 'gcr.io/$PROJECT_ID/nix-built-mysql']
+  volumes:
+  - name: nix-store
+    path: /nix/
+# docker-load the built image.
+- name: gcr.io/cloud-builders/docker
+  args: ['load', '-i', './result']
+  volumes:
+  - name: nix-store
+    path: /nix/
+
+images:
+- gcr.io/$PROJECT_ID/nix-build
+- gcr.io/$PROJECT_ID/nix-built-mysql
+

--- a/nix-build/default.nix
+++ b/nix-build/default.nix
@@ -1,0 +1,12 @@
+let
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/grahamc/nixpkgs/archive/layered-docker-images.tar.gz";
+    sha256 = "05a3jjcqvcrylyy8gc79hlcp9ik9ljdbwf78hymi5b12zj2vyfh6";
+  }) {};
+in pkgs.dockerTools.buildLayeredImage {
+  # TODO: This needs to be an arg that's passed at build-time from the nix-build CLI.
+  name = "gcr.io/$PROJECT_ID/nix-built-mysql";
+  tag = "latest";
+  config.Cmd = [ "${pkgs.mysql}/bin/mysqld" ];
+  maxLayers = 120;
+}

--- a/nix-build/default.nix
+++ b/nix-build/default.nix
@@ -1,3 +1,4 @@
+{ imageName }:
 let
   pkgs = import (builtins.fetchTarball {
     url = "https://github.com/grahamc/nixpkgs/archive/layered-docker-images.tar.gz";
@@ -5,7 +6,7 @@ let
   }) {};
 in pkgs.dockerTools.buildLayeredImage {
   # TODO: This needs to be an arg that's passed at build-time from the nix-build CLI.
-  name = "gcr.io/$PROJECT_ID/nix-built-mysql";
+  name = imageName;
   tag = "latest";
   config.Cmd = [ "${pkgs.mysql}/bin/mysqld" ];
   maxLayers = 120;

--- a/nix-build/default.nix
+++ b/nix-build/default.nix
@@ -5,7 +5,6 @@ let
     sha256 = "05a3jjcqvcrylyy8gc79hlcp9ik9ljdbwf78hymi5b12zj2vyfh6";
   }) {};
 in pkgs.dockerTools.buildLayeredImage {
-  # TODO: This needs to be an arg that's passed at build-time from the nix-build CLI.
   name = imageName;
   tag = "latest";
   config.Cmd = [ "${pkgs.mysql}/bin/mysqld" ];


### PR DESCRIPTION
This adds a builder to use the [Nix build system](https://nixos.org/nix/manual/#sec-nix-build), which executes builds described in the Nix config language, and an example script to produce a layered Docker image based on [these instructions](https://grahamc.com/blog/nix-and-layered-docker-images).

cc @rafikk