### PR TITLE
Add makisu example

### DIFF
--- a/makisu/Dockerfile
+++ b/makisu/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu
+
+RUN apt-get update -y
+RUN apt-get install -y ca-certificates #!COMMIT

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -1,0 +1,5 @@
+# Makisu
+
+This directory contains an example of using [Uber's Makisu
+tool](https://github.com/uber/makisu) to produce Docker images in
+Google Cloud Build.

--- a/makisu/cloudbuild.yaml
+++ b/makisu/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: gcr.io/makisu-project/makisu:v0.1.0
+  args: ['build', '--load', '--modifyfs=true', '-t', 'gcr.io/$PROJECT_ID/built-with-makisu', '--commit=explicit', '.']
+
+# TODO: Instead of building with --load into the Docker daemon
+# then pushing, use --push=gcr.io which will push directly to the
+# registry and bypass the Docker daemon. Unfortunately, this seems
+# to not work with Google's Application Default Credentials.
+
+images:
+- gcr.io/$PROJECT_ID/built-with-makisu


### PR DESCRIPTION
This demonstrates using Uber's [`makisu`](https://github.com/uber/makisu) in Google Cloud Build to produce Docker images, instead of using `docker build`.

Unfortunately, seemingly due to an issue to consume the GCB builder service account's Application Default Credentials, this still has to depend on the Docker daemon and `--load` the image before pushing it. If we can fix that, we could replace `--load` with `--push=gcr.io` and push the image directly to the registry.

The error when using `--push=gcr.io` is:

```
2018/11/21 19:19:52 Command failure: failed to push image: failed to push image: check manifest exists for image gcr.io/my-project/built-with-makisu:latest: check manifest exists: HEAD https://gcr.io/v2/my-project/built-with-makisu/manifests/latest 401
```

cc @yiranwang52