### PR TITLE
Add kaniko example

### DIFF
--- a/kaniko/Dockerfile
+++ b/kaniko/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu
+
+RUN apt-get -y update && \
+    apt-get -y install ca-certificates

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -1,0 +1,8 @@
+# kaniko
+
+This demonstrates using the
+[`kaniko`](https://github.com/GoogleContainerTools/kaniko) tool in Google Cloud
+Build to produce Docker images in a registry, instead of using `docker build`
+and `docker push`.
+
+

--- a/kaniko/cloudbuild.yaml
+++ b/kaniko/cloudbuild.yaml
@@ -1,0 +1,3 @@
+steps:
+- name: gcr.io/kaniko-project/executor:latest
+  args: ['--destination=gcr.io/$PROJECT_ID/built-with-kaniko']

--- a/kaniko/cloudbuild.yaml
+++ b/kaniko/cloudbuild.yaml
@@ -1,3 +1,4 @@
 steps:
 - name: gcr.io/kaniko-project/executor:latest
-  args: ['--destination=gcr.io/$PROJECT_ID/built-with-kaniko']
+  args: ['--destination=gcr.io/$PROJECT_ID/built-with-kaniko',
+         '--cache=true']


### PR DESCRIPTION
This demonstrates using [`kaniko`](https://github.com/GoogleContainerTools/kaniko) in Google Cloud Build to produce Docker images, instead of using `docker build`.

The Kaniko project produces its own GCB-compatible builder image (`gcr.io/kaniko-project/executor:latest`), which we should use instead of building our own. This is just a runnable example of using it in GCB.

The `--cache=true` flag results in faster subsequent builds; in my totally unscientific test, the example build without caching took 36s, and a build using the cache took 16s.