### PR TITLE
Helm Tillerless tweaks

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v2.10.0
+ARG HELM_VERSION=v2.12.0
 
 COPY helm.bash /builder/helm.bash
 

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x /builder/helm.bash && \
   apt-get update && \
   apt-get install -y curl && \
   curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
-  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm && \
+  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm linux-amd64/tiller && \
   rm helm.tar.gz && \
   apt-get --purge -y autoremove && \
   apt-get clean && \

--- a/helm/README.md
+++ b/helm/README.md
@@ -68,12 +68,16 @@ And to list Helm releases.
 
 ### Tillerless Helm setup
 
-`Tillerless Helm` which solves all those `tiller` security issues, as `tiller` runs outside the GKE cluster.
-I wrote a [blog post](https://rimusz.net/tillerless-helm/) how to use Helm local [tiller plugin](https://github.com/rimusz/helm-tiller).
+`Tillerless Helm` solves many `tiller` [security issues](https://docs.helm.sh/using_helm/#securing-your-helm-installation), as `tiller` runs outside the GKE cluster, locally in the container, and stores configs as secrets using the [secrets storage backend](https://docs.helm.sh/using_helm/#storage-backends).
+It is based on the [Tillerless](https://rimusz.net/tillerless-helm/) [plugin](https://github.com/rimusz/helm-tiller), and is available in the image.
+
+#### Enabling Tillerless Helm
+
+Set `TILLERLESS=true` and optionally `TILLER_NAMESPACE=<namespace>`.
 
 You can test e.g. installing a chart via `Tillerless Helm`, running the following command.
 
-    gcloud builds submit . --config=examples/chart-install-tillerless/cloudbuild.yaml
+    $ gcloud builds submit . --config=examples/chart-install-tillerless/cloudbuild.yaml
 
 And to list Helm releases.
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.10.0', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.12.0', '.']
 
 images: ['gcr.io/$PROJECT_ID/helm']

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -44,19 +44,27 @@ fi
 echo "Running: helm repo update"
 helm repo update
 
-# check if Tillerless value 'TILLERLESS=true' is provided then install and start the plugin
+
+# if 'TILLERLESS=true' is set, run a local tiller server with the secret backend
+# see also https://github.com/helm/helm/blob/master/docs/securing_installation.md#running-tiller-locally
 if [ "$TILLERLESS" = true ]; then
-  echo "Installing Tillerless plugin"
-  helm plugin install https://github.com/rimusz/helm-tiller
-  echo "Starting Tillerless plugin"
-  helm tiller start-ci "$TILLER_NAMESPACE"
-  echo
+  # create tiller-namespace if it doesn't exist (helm --init would usually do this with server-side tiller'
+  if [[ -n $TILLER_NAMESPACE ]]; then
+    echo "Creating tiller namespace $TILLER_NAMESPACE"
+    kubectl get namespace $TILLER_NAMESPACE || kubectl create namespace $TILLER_NAMESPACE
+  fi
+
+  echo "Starting local tiller server"
+  #default inherits --listen localhost:44134 and TILLER_NAMESPACE
+  #use the secret driver by default
+  tiller --storage=secret &
   export HELM_HOST=localhost:44134
   if [ "$DEBUG" = true ]; then
       echo "Running: helm $@"
   fi
   helm "$@"
-  helm tiller stop
+  echo "Stopping local tiller server"
+  pkill tiller
 else
   if [ "$DEBUG" = true ]; then
       echo "Running: helm $@"


### PR DESCRIPTION
## Why

* The current implementation of tillerless helm works well, but downloads the tiller binary and tillerless plugin every build. This causes unnecessarily long build times. Most plugin functionality is not needed for non-interactive use.
* The helm default versions are out of date
* The README for RBAC clusters is incomplete and a bit roundabout

## What this does

* Install tiller locally in the Dockerfile (it was already pulled but discarded from the tarball)
  - adds about 23 MB to the compressed image
* Modify helm.bash to use the locally installed tiller in a similar manner to the plugin which was previously used
  - start tiller in the background
  - tell helm to connect to the local tiller
  - pkill tiller
* Bump helm to 2.12.0
* Update the README

## Benefits
* Speeds up build startup on standard-machine from 70sec to 10sec