### PR TITLE
Helm GCS plugin

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -98,3 +98,15 @@ And to list Helm releases.
     # and add a clusterrolebinding
     $ kubectl create clusterrolebinding cluster-admin-${SERVICE_ACCOUNT} \
       --clusterrole cluster-admin --user ${SERVICE_ACCOUNT}
+
+## Configuration
+
+The following options are configurable via environment variables passed to the build step in the `env` parameter:
+
+| Option        | Description   |
+| ------------- | ------------- |
+| GCS_PLUGIN_VERSION | [GCS plugin](https://github.com/nouney/helm-gcs) version to install, optional |
+| HELM_REPO_NAME | External Helm repository name, optional |
+| HELM_REPO_URL | External Helm repo URL, optional |
+| TILLERLESS | If true, Tillerless Helm is enabled, optional |
+| TILLER_NAMESPACE | Tiller namespace, optional |

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -35,6 +35,12 @@ fi
 echo "Running: helm init --client-only"
 helm init --client-only
 
+# if GCS_PLUGIN_VERSION is set, install the plugin
+if [[ -n $GCS_PLUGIN_VERSION ]]; then
+  echo "Installing helm GCS plugin version $GCS_PLUGIN_VERSION "
+  helm plugin install https://github.com/nouney/helm-gcs --version $GCS_PLUGIN_VERSION
+fi
+
 # check if repo values provided then add that repo
 if [[ -n $HELM_REPO_NAME && -n $HELM_REPO_URL ]]; then
   echo "Adding chart helm repo $HELM_REPO_URL "


### PR DESCRIPTION
If `GCS_PLUGIN_VERSION` build env var is set, install the [plugin](https://github.com/nouney/helm-gcs)