### PR TITLE
Firebase builder: Step missing to set $TOKEN used for encrypting

### DIFF
--- a/firebase/README.md
+++ b/firebase/README.md
@@ -15,6 +15,11 @@ This command will generate a new CI token that will be encrypted by the KMS to b
 ```
 firebase login:ci
 ```
+This will print your token on screen after login. Once done use the below command to set it to $TOKEN variable, which is used by the commands below to encrypt it.
+
+```
+TOKEN=<GENERATED_TOKEN>
+```
 
 **Enable the KMS API**
 


### PR DESCRIPTION
The glcoud encrypt command uses $TOKEN variable, which is not set anywhere.