### PR TITLE
firebase: allow for IAM or token based auth

### DIFF
--- a/firebase/README.md
+++ b/firebase/README.md
@@ -8,6 +8,22 @@ command](https://firebase.google.com/docs/cli/#command_reference).
 
 ## Usage
 
+### With IAM roles
+
+Ensure you have the following APIs enabled
+
+1. [Cloud Resource Manager API](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com)
+2. [Firebase Management API](https://console.developers.google.com/apis/api/firebase.googleapis.com)
+3. [Firebase Hosting API](https://console.developers.google.com/apis/api/firebasehosting.googleapis.com)
+
+**Add permission to the cloudbuilder**
+
+- Open GCP IAM menu
+- Find email ending with `@cloudbuild.gserviceaccount.com`
+- Add `Cloud Build Service Account`, `Firebase Admin`, and `API Keys Admin` roles to this account
+
+### With Token
+
 **Get the firebase token**
 
 This command will generate a new CI token that will be encrypted by the KMS to be used within the CLI
@@ -25,13 +41,13 @@ Click "setup" or "enable API" on https://console.cloud.google.com/security/kms
 This step will encrypt the token via KMS. Remember to replace `GENERATED_TOKEN` in the text
 
 ```bash
-# create a keyring for cloudbuilder-related keys
+#### create a keyring for cloudbuilder-related keys
 gcloud kms keyrings create cloudbuilder --location global
 
-# create a key for the firebase token
+#### create a key for the firebase token
 gcloud kms keys create firebase-token --location global --keyring cloudbuilder --purpose encryption
 
-# create the encrypted token
+#### create the encrypted token
 echo -n $TOKEN | gcloud kms encrypt \
   --plaintext-file=- \
   --ciphertext-file=- \

--- a/firebase/firebase.bash
+++ b/firebase/firebase.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 # run the original firebase
-firebase "$@" --token $FIREBASE_TOKEN
+if [ $FIREBASE_TOKEN ]; then
+  firebase "$@" --token $FIREBASE_TOKEN
+else
+  firebase "$@"
+fi


### PR DESCRIPTION
The current approach for authenticating with FireBase required
generating and manually managing a key via KMS. This update documents
how to authenticate via IAM roles instead, which is much simpler.

`firebase.bash` has been updated to allow for the `$FIREBASE_TOKEN` to
be committed, but will still support it for the legacy use case

Fixes: https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/157