### PR TITLE
Helm Tillerless exit code

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v2.12.0
+ARG HELM_VERSION=v2.12.1
 
 COPY helm.bash /builder/helm.bash
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.12.0', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.12.1', '.']
 
 images: ['gcr.io/$PROJECT_ID/helm']

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -69,8 +69,10 @@ if [ "$TILLERLESS" = true ]; then
       echo "Running: helm $@"
   fi
   helm "$@"
+  exitCode=$?
   echo "Stopping local tiller server"
   pkill tiller
+  exit $exitCode
 else
   if [ "$DEBUG" = true ]; then
       echo "Running: helm $@"


### PR DESCRIPTION
Tillerless Helm fails silently: exit code is not specified in the script, so it's the exit code of the last command, which is `pkill tiller` (always 0)

This fix solves this issue, also bumps Helm version.