### PR TITLE
awscli image support

### DIFF
--- a/awscli/.gitignore
+++ b/awscli/.gitignore
@@ -1,0 +1,1 @@
+testaws

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3-alpine
+RUN apk add --update \
+    groff \
+    less  \
+  && pip install awscli \
+  && rm -rf /var/cache/apk/* ~/.cache/pip
+ENV PAGER=less
+ENTRYPOINT ["aws"]

--- a/awscli/README.md
+++ b/awscli/README.md
@@ -1,0 +1,58 @@
+# aws command line interface
+
+This is a tool build to simply invoke the
+[`awscli`](https://aws.amazon.com/cli/).
+
+`awscli` is useful for managing resources and deploying applications
+across AWS and GCP
+
+Arguments passed to this builder will be passed to `awscli` directly.
+
+## Quick Start
+
+1. Build this image and add it to your gcr repo
+
+```
+$ git clone git@github.com:GoogleCloudPlatform/cloud-builders
+$ cd cloud-builders/aws-cli
+$ gcloud builds submit .
+```
+
+2. Add the steps to your `cloudbuild.yaml`
+
+```
+$ cd my-project
+$ cat >> cloudbuild.yaml
+steps:
+- name: gcr.io/$PROJECT_ID/awscli
+  args: ['s3', 'sync', '/workspace/', 's3://my-bucket/]
+  env: ["AWS_ACCESS_KEY_ID=XXXXXXXXXXXXX", "AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYYYY"]
+CTRL-D
+```
+
+3. Submit a manual build of your project to Cloud Build
+```
+$ cd my-project
+$ gcloud builds submit .
+```
+
+At this point you can automate the build using triggers via GCP Repos or Github
+
+
+## Authentication
+
+AWS Authentication credentials are passed in via environment variables.
+```
+env: ["AWS_ACCESS_KEY_ID=XXXXXXXXXXXX", "AWS_SECRET_ACCESS_KEY=YYYYYYYYYYY"]
+```
+
+## Example: Deploy Files to S3 Bucket
+
+
+**Be sure to set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY**
+```
+steps:
+- name: gcr.io/$PROJECT_ID/awscli
+  args: ['s3', 'sync', '/workspace/', 's3://my-bucket/]
+  env: ["AWS_ACCESS_KEY_ID=XXXXXXXXXXXXX", "AWS_SECRET_ACCESS_KEY=YYYYYYYYYYYYYY"]
+```

--- a/awscli/cloudbuild.yaml
+++ b/awscli/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/awscli', '.']
+
+# Print version information.
+- name: gcr.io/$PROJECT_ID/awscli
+  args: ['s3', 'help']
+
+images: ['gcr.io/$PROJECT_ID/awscli']


### PR DESCRIPTION
- based on `python3-alpine` . Added compatibility pkgs
- ~140mb in size
- see README for usage. 
- great for migrating projects out of AWS and into GCP