### PR TITLE
Test make example in main cloudbuild

### DIFF
--- a/make/cloudbuild.yaml
+++ b/make/cloudbuild.yaml
@@ -7,5 +7,12 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/make'
   args: ['-v']
 
+# Test the examples with :latest
+
+# hello_world
+- name: 'gcr.io/$PROJECT_ID/make:latest'
+  args: ['all']
+  dir: 'examples'
+
 images:
 - 'gcr.io/$PROJECT_ID/make'

--- a/make/cloudbuild.yaml
+++ b/make/cloudbuild.yaml
@@ -4,13 +4,15 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/make', '.']
+  dir: 'make'
 - name: 'gcr.io/$PROJECT_ID/make'
   args: ['-v']
+  dir: 'make'
 
 # Test the example with :latest
 - name: 'gcr.io/$PROJECT_ID/make:latest'
   args: ['all']
-  dir: 'examples'
+  dir: 'make/examples'
 
 images:
 - 'gcr.io/$PROJECT_ID/make'

--- a/make/cloudbuild.yaml
+++ b/make/cloudbuild.yaml
@@ -7,9 +7,7 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/make'
   args: ['-v']
 
-# Test the examples with :latest
-
-# hello_world
+# Test the example with :latest
 - name: 'gcr.io/$PROJECT_ID/make:latest'
   args: ['all']
   dir: 'examples'


### PR DESCRIPTION
I've set up a Google Cloud Build for this specific builder, as an example.

There is one caveat: I had to add a `dir` in the cloudbuild steps, which means people will have to run this specific builder from the root directory: `gcloud builds submit --config=make/cloudbuild.yaml make/.`

I added the run of the example in the make/cloudbuild.yaml.