### PR TITLE
Minimal docker image for slackbot

### DIFF
--- a/slackbot/Dockerfile
+++ b/slackbot/Dockerfile
@@ -6,4 +6,10 @@ ENV GOBIN=/go/bin
 RUN go get -d -v ./...
 RUN go install /go/src/main.go
 
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=build-env /go/bin/main /go/bin/main
+
 ENTRYPOINT [ "/go/bin/main" ]


### PR DESCRIPTION
#### What this PR does

* Reduces the time to run the slackbot step in a build from 15-30 seconds to 4 seconds or less
* Reduces the size of the slackbot docker image from 371.5MB to 6.4MB (based on virtual sizes reported in GCR)

#### How it's done

Changed the `Dockerfile` to a two-stage build, with the second stage based on `alpine:latest`.

Reference: https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324 

#### How it's tested

The new slackbot docker image was manually tested on the three examples and gives the same (but faster) results as the previous slackbot docker image.