### PR TITLE
Fix the location of the build cache.

### DIFF
--- a/android/examples/build-test-deploy.yaml
+++ b/android/examples/build-test-deploy.yaml
@@ -68,7 +68,7 @@ steps:
   args:
   - '-c'
   - |
-    tar xpzf /build_cache/cache.tgz -C /build_cache || echo "No cache found."
+    tar xpzf /build_cache/cache.tgz -C / || echo "No cache found."
   volumes:
   - name: 'build_cache'
     path: '/build_cache'


### PR DESCRIPTION
When extracting the cache, we need to extract to root because the tar file already has the /build_cache folder inside. 
The way it is right now, it will extract all under /build_cache/build_cache/.gradle instead of the expected /build_cache/.gradle