### PR TITLE
Terraform apt-get cleanup

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && \
     echo "${TERRAFORM_VERSION_SHA256SUM} terraform_linux_amd64.zip" > terraform_SHA256SUMS && \
     sha256sum -c terraform_SHA256SUMS --status && \
     unzip terraform_linux_amd64.zip -d /builder/terraform && \
-    rm -f terraform_linux_amd64.zip
+    rm -f terraform_linux_amd64.zip && \
+    apt-get remove --purge -y curl unzip && \
+    apt-get --purge -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/builder/terraform/:$PATH
 COPY entrypoint.bash /builder/entrypoint.bash


### PR DESCRIPTION
Clean up `terraform` builder's `apt-get` left-overs and extra packages.