### PR TITLE
Add "envsubst" Cloud Build builder

### DIFF
--- a/envsubst/Dockerfile
+++ b/envsubst/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.8
+RUN apk add --no-cache bash gettext
+COPY entrypoint.bash /builder/entrypoint.bash
+ENTRYPOINT ["/builder/entrypoint.bash"]

--- a/envsubst/README.markdown
+++ b/envsubst/README.markdown
@@ -1,0 +1,38 @@
+# envsubst cloud builder
+
+## envsubst cloud builder
+This builder can be used to pre-process files for environment variables using `envsubst`.
+
+### Building this builder
+To build this builder, run the following command in this directory.
+```sh
+$ gcloud builds submit --config=cloudbuild.yaml
+```
+
+## Using this builder
+
+Assuming you have the file `planetary-message.txt` you wish to pre-process in your build:
+```
+This is a text message from planet ${PLANET}.
+```
+
+Use the following step to do it:
+```yaml
+- id: preprocess-resources
+  name: gcr.io/${PROJECT_ID}/envsubst
+  env: ["PLANET=Mars"]
+  args: ["message.txt"]
+```
+
+The image can also accept wildcards! Lets say you have another file called `info.txt`:
+```
+The planet ${PLANET} is the next one on the solar system!
+```
+
+You can pass a wildcard, like so:
+```yaml
+- id: preprocess-resources
+  name: gcr.io/${PROJECT_ID}/envsubst
+  env: ["PLANET=Mars"]
+  args: ["*.txt"]
+```

--- a/envsubst/cloudbuild.yaml
+++ b/envsubst/cloudbuild.yaml
@@ -1,0 +1,12 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/${PROJECT_ID}/envsubst', '.']
+- name: 'gcr.io/${PROJECT_ID}/envsubst'
+  env: ["TEST=value"]
+  args: ['test.txt']
+- name: 'gcr.io/${PROJECT_ID}/envsubst'
+  entrypoint: sh
+  args: ['-c', '[[ "$(cat test.txt)" == "test=value" ]]']
+images: ['gcr.io/${PROJECT_ID}/envsubst']

--- a/envsubst/entrypoint.bash
+++ b/envsubst/entrypoint.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+if [[ $# == 0 ]]; then
+    echo "Please specify list of files to pre-process" >&2
+    exit 1
+fi
+
+set -eu -o pipefail
+
+for f in $(ls $@); do
+    cat ${f} | envsubst > ${f}.processed
+    mv ${f}.processed ${f}
+done
+
+exit 0

--- a/envsubst/test.txt
+++ b/envsubst/test.txt
@@ -1,0 +1,1 @@
+test=${TEST}


### PR DESCRIPTION
This builder is intended to pre-process resources in the project workspace via environment variables. 

The tool used for the processing of the files is "envsubst" (from the "gettext" GNU package).