### PR TITLE
Add support for dotenv files in "envsubst" builder

### DIFF
--- a/envsubst/README.markdown
+++ b/envsubst/README.markdown
@@ -24,7 +24,7 @@ Use the following step to do it:
   args: ["message.txt"]
 ```
 
-The image can also accept wildcards! Lets say you have another file called `info.txt`:
+This builder can also accept wildcards! Lets say you have another file called `info.txt`:
 ```
 The planet ${PLANET} is the next one on the solar system!
 ```
@@ -35,4 +35,17 @@ You can pass a wildcard, like so:
   name: gcr.io/${PROJECT_ID}/envsubst
   env: ["PLANET=Mars"]
   args: ["*.txt"]
+```
+
+This builder can also read environment variables from a `.env` file. Let's assume you have another file called `test.env`:
+
+```dotenv
+PLANET=Mars
+```
+
+You can instruct the builder to use this file to get environment variables from, like so:
+```yaml
+- id: preprocess-resources
+  name: gcr.io/${PROJECT_ID}/envsubst
+  args: ["-e", "test.env", "*.txt"]
 ```

--- a/envsubst/cloudbuild.yaml
+++ b/envsubst/cloudbuild.yaml
@@ -4,9 +4,11 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/${PROJECT_ID}/envsubst', '.']
 - name: 'gcr.io/${PROJECT_ID}/envsubst'
-  env: ["TEST=value"]
-  args: ['test.txt']
-- name: 'gcr.io/${PROJECT_ID}/envsubst'
+  env: ["MARS_COLOR=Red"]
+  args: ['-e', 'test.env', 'test.txt']
+- name: alpine
+  args: [cat, 'test.txt']
+- name: alpine
   entrypoint: sh
-  args: ['-c', '[[ "$(cat test.txt)" == "test=value" ]]']
+  args: ['-c', '[[ "$(cat test.txt)" == "Mars is Red and Neptune is Blue" ]]']
 images: ['gcr.io/${PROJECT_ID}/envsubst']

--- a/envsubst/entrypoint.bash
+++ b/envsubst/entrypoint.bash
@@ -39,7 +39,7 @@ fi
 
 # Iterate files/wildcards and pre-process them using envsubst
 for f in $(ls ${files[*]}); do
-    echo "Pre-processing ..." >&2
+    echo "Pre-processing ${f}..." >&2
     cat ${f} | envsubst > ${f}.processed
     mv ${f}.processed ${f}
 done

--- a/envsubst/entrypoint.bash
+++ b/envsubst/entrypoint.bash
@@ -1,12 +1,45 @@
 #!/usr/bin/env bash
-if [[ $# == 0 ]]; then
+
+set -eu -o pipefail
+declare -a files
+files_count=0
+
+function usage() {
+    echo "usage: $0 [-e <env-file1>] file1 [file2...fileN]" >&2
+    echo "  -h    show this help screen" >&2
+    echo "  -e    add environment variables from this env file (can be specified multiple times)'" >&2
+    exit 0
+}
+
+# Parse command line flags
+while true; do
+    [[ $# == 0 ]] && break
+    case "${1}" in
+        -h|--help)
+            usage
+            ;;
+        -e|--env)
+            [[ -z "${2}" ]] && usage
+            export $(grep -v '^#' ${2} | xargs)
+            shift 2
+            ;;
+        *)
+            files[files_count]="${1}"
+            files_count=$((  + 1 ))
+            shift
+            ;;
+    esac
+done
+
+# Fail if no files/wildcards were provided
+if [[ ${files_count} == 0 ]]; then
     echo "Please specify list of files to pre-process" >&2
     exit 1
 fi
 
-set -eu -o pipefail
-
-for f in $(ls $@); do
+# Iterate files/wildcards and pre-process them using envsubst
+for f in $(ls ${files[*]}); do
+    echo "Pre-processing ..." >&2
     cat ${f} | envsubst > ${f}.processed
     mv ${f}.processed ${f}
 done

--- a/envsubst/test.env
+++ b/envsubst/test.env
@@ -1,0 +1,1 @@
+NEPTUNE_COLOR=Blue

--- a/envsubst/test.txt
+++ b/envsubst/test.txt
@@ -1,1 +1,1 @@
-test=${TEST}
+Mars is ${MARS_COLOR} and Neptune is ${NEPTUNE_COLOR}


### PR DESCRIPTION
This allows providing environment variables via dotenv files to the `envsubst` builder. 

This can be useful when the environment variables are dynamic in nature and need to be generated by another step first.