### PR TITLE
Fix /workspace is not within a known GOPATH/src

### DIFF
--- a/dep/Dockerfile
+++ b/dep/Dockerfile
@@ -15,4 +15,6 @@ ENV PATH=/builder/bin:$PATH
 # Build the go_workspace for detecting the workspace
 RUN go build -o /builder/go_workspace /builder/go_workspace.go
 
+ENV GOPATH=
+
 ENTRYPOINT ["dep.bash"]


### PR DESCRIPTION
It works for me to address
```
Running: dep ensure -v
/workspace is not within a known GOPATH/src
```

See also
https://github.com/GoogleCloudPlatform/cloud-builders-community/pull/69