### PR TITLE
add s2i support to google cloud build

### DIFF
--- a/s2i/Dockerfile
+++ b/s2i/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcr.io/cloud-builders/docker
+
+ARG version=1.1.13
+ARG commit=b54d75d3
+
+RUN \
+  curl -L "https://github.com/openshift/source-to-image/releases/download/v$version/source-to-image-v$version-$commit-linux-amd64.tar.gz" -o /tmp/release.tar.gz && \
+  tar -C /tmp -xzvf /tmp/release.tar.gz  && \
+  cp /tmp/s2i /usr/local/bin && \
+  chmod +x /usr/local/bin/s2i 
+
+ENTRYPOINT ["/usr/local/bin/s2i"]

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -2,6 +2,10 @@
 
 This bulid step invokes `s2i` commands in [Google Cloud Build](cloud.google.com/cloud-build/)
 
+By using this builder you are uploading a s2i builder image to your project (i.e. gcr.io/$PROJECT_ID/s2i.
+
+You may run into authentication issue if you were running s2i on top of a image registered in your private gcr repo. One way to work around is to add a docker step in cloud build to pull that image before your s2i step.
+
 [s2i](https://github.com/openshift/source-to-image) is a tookit and workflow for building reproducible Docker images from source code.
 
 Arguments passed to this builder will be passed to `s2i` directly, allowing callers to build images with `s2i` directly.

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -1,0 +1,11 @@
+# s2i builder
+
+This bulid step invokes `s2i` commands in [Google Cloud Build](cloud.google.com/cloud-build/)
+
+[s2i](https://github.com/openshift/source-to-image) is a tookit and workflow for building reproducible Docker images from source code.
+
+Arguments passed to this builder will be passed to `s2i` directly, allowing callers to build images with `s2i` directly.
+
+## Examples
+
+See examples in the `examples` subdirectry.

--- a/s2i/cloudbuild.yaml
+++ b/s2i/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg'
+  - 'version=1.1.13'
+  - '--build-arg'
+  - 'commit=b54d75d3'
+  - '-t'
+  - 'gcr.io/$PROJECT_ID/s2i:latest'
+  - '-t'
+  - 'gcr.io/$PROJECT_ID/s2i:1.1.13'
+  - '.'
+- name: 'gcr.io/$PROJECT_ID/s2i'
+  args: ['version']
+
+images:
+- 'gcr.io/$PROJECT_ID/s2i:latest'
+- 'gcr.io/$PROJECT_ID/s2i:1.1.13'

--- a/s2i/examples/hello-python/README.md
+++ b/s2i/examples/hello-python/README.md
@@ -1,0 +1,8 @@
+# s2i hello-python example
+
+This `cloudbuild.yaml` invokes a `s2i build` with the hello-python example provided by the [s2i github readme](https://github.com/openshift/source-to-image):
+```
+gcloud builds submit --config=cloudbuild.yaml .
+docker pull gcr.io/<your-project>/s2i-hello-python
+docker run -p :8080 gcr.io/<your-project>/s2i-hello-python
+```

--- a/s2i/examples/hello-python/cloudbuild.yaml
+++ b/s2i/examples/hello-python/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/s2i'
+  args: ['build', 'https://github.com/sclorg/django-ex', 'centos/python-35-centos7', 'gcr.io/$PROJECT_ID/s2i-hello-python']
+
+images:
+- 'gcr.io/$PROJECT_ID/s2i-hello-python'

--- a/s2i/examples/test-ruby-app/README.md
+++ b/s2i/examples/test-ruby-app/README.md
@@ -1,0 +1,8 @@
+# s2i test-ruby-app example
+
+This `cloudbuild.yaml` invokes a `s2i build` with the test-ruby-app provided by the [s2i github readme](https://github.com/openshift/source-to-image):
+```
+gcloud builds submit --config=cloudbuild.yaml .
+docker pull gcr.io/<your-project>/s2i-test-ruby-app
+docker run --rm -i -p :8080 -t gcr.io/<your-project>/s2i-test-ruby-app
+```

--- a/s2i/examples/test-ruby-app/cloudbuild.yaml
+++ b/s2i/examples/test-ruby-app/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/s2i'
+  args: ['build', 'https://github.com/openshift/ruby-hello-world', 'centos/ruby-23-centos7', 'gcr.io/$PROJECT_ID/s2i-test-ruby-app']
+
+images:
+- 'gcr.io/$PROJECT_ID/s2i-test-ruby-app'


### PR DESCRIPTION
This will create a s2i builder image that can be pushed to `gcr.io/$PROJECT_ID/s2i`