### PR TITLE
Update Terraform version to 0.11.13

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV TERRAFORM_VERSION=0.11.11
-ENV TERRAFORM_VERSION_SHA256SUM=94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c
+ENV TERRAFORM_VERSION=0.11.13
+ENV TERRAFORM_VERSION_SHA256SUM=5925cd4d81e7d8f42a0054df2aafd66e2ab7408dbed2bd748f0022cfe592f8d2
 
 RUN apt-get update && \
     apt-get -y install curl unzip ca-certificates && \


### PR DESCRIPTION
This updates the Terraform builder to use version 0.11.13, up from 0.11.11.

The checksum was pulled from https://releases.hashicorp.com/terraform/0.11.13/
