### PR TITLE
adds an option to save_cache to skip saving if cache exists in GCS

### DIFF
--- a/cache/cloudbuild.yaml
+++ b/cache/cloudbuild.yaml
@@ -128,7 +128,7 @@ steps:
 
 
 substitutions:
-  _VERSION: '1.0'
+  _VERSION: '1.1'
 
 images: 
 - 'gcr.io/$PROJECT_ID/cache:${_VERSION}'

--- a/cache/save_cache
+++ b/cache/save_cache
@@ -11,12 +11,12 @@ function print_usage {
   echo
   echo "Saves the specified paths to a cache file located in the out directory."
   echo
-  echo "  -b, --bucket          The cloud storage bucket to upload the cache to. [optional]"
-  echo "  -o, --out             The output directory to write the cache to. [optional]"
-  echo "  -k, --key             The cache key used for this cache file."
-  echo "  -p, --path            The files to store in the cache. Can be repeated."
-  echo "  -t, --threshold       The parallel composite upload threshold [default: 50M]"
-  echo "  -s, --skip_if_exists  Skips the save if the cache file already exists in GCS."
+  echo "  -b, --bucket      The cloud storage bucket to upload the cache to. [optional]"
+  echo "  -o, --out         The output directory to write the cache to. [optional]"
+  echo "  -k, --key         The cache key used for this cache file."
+  echo "  -p, --path        The files to store in the cache. Can be repeated."
+  echo "  -t, --threshold   The parallel composite upload threshold [default: 50M]"
+  echo "  -n, --no-clobber  Skips the save if the cache file already exists in GCS."
   echo
 }
 
@@ -42,8 +42,8 @@ for i in "$@"; do
       THRESHOLD="${i#*=} "
       shift
       ;;
-    -s|--skip_if_exists)
-      SKIP_IF_EXISTS=true
+    -n|--no-clobber)
+      NO_CLOBBER=true
       shift
       ;;
     -h|--help )
@@ -63,8 +63,8 @@ if [ -z "$KEY" ] || [ -z "$PATHS" ];then
   exit 1
 fi
 
-if [ "$SKIP_IF_EXISTS" = true ] && [ -z "$BUCKET" ];then
-  echo "--bucket must be specified if --skip_if_exists is used"
+if [ "$NO_CLOBBER" = true ] && [ -z "$BUCKET" ];then
+  echo "--bucket must be specified if --no-clobber is used"
   echo
   print_usage
   exit 1
@@ -74,7 +74,7 @@ eval "KEY=$KEY"
 
 CACHE_FILE="${OUT_DIR}/${KEY}.tgz"
 
-if [ "$SKIP_IF_EXISTS" = true ];then
+if [ "$NO_CLOBBER" = true ];then
   BUCKET_FILE="$BUCKET/$KEY.tgz"
   FILE_LS=$(gsutil ls "$BUCKET_FILE")
   if [ "$FILE_LS" == "$BUCKET_FILE" ];then

--- a/cache/save_cache
+++ b/cache/save_cache
@@ -11,12 +11,13 @@ function print_usage {
   echo
   echo "Saves the specified paths to a cache file located in the out directory."
   echo
-  echo "  -b, --bucket     The cloud storage bucket to upload the cache to. [optional]"
-  echo "  -o, --out        The output directory to write the cache to. [optional]"
-  echo "  -k, --key        The cache key used for this cache file."
-  echo "  -p, --path       The files to store in the cache. Can be repeated."
-  echo "  -t, --threshold  The parallel composite upload threshold [default: 50M]"
-  echo 
+  echo "  -b, --bucket          The cloud storage bucket to upload the cache to. [optional]"
+  echo "  -o, --out             The output directory to write the cache to. [optional]"
+  echo "  -k, --key             The cache key used for this cache file."
+  echo "  -p, --path            The files to store in the cache. Can be repeated."
+  echo "  -t, --threshold       The parallel composite upload threshold [default: 50M]"
+  echo "  -s, --skip_if_exists  Skips the save if the cache file already exists in GCS."
+  echo
 }
 
 for i in "$@"; do
@@ -41,6 +42,10 @@ for i in "$@"; do
       THRESHOLD="${i#*=} "
       shift
       ;;
+    -s|--skip_if_exists)
+      SKIP_IF_EXISTS=true
+      shift
+      ;;
     -h|--help )
       print_usage
       exit 0
@@ -58,9 +63,25 @@ if [ -z "$KEY" ] || [ -z "$PATHS" ];then
   exit 1
 fi
 
+if [ "$SKIP_IF_EXISTS" = true ] && [ -z "$BUCKET" ];then
+  echo "--bucket must be specified if --skip_if_exists is used"
+  echo
+  print_usage
+  exit 1
+fi
+
 eval "KEY=$KEY"
 
 CACHE_FILE="${OUT_DIR}/${KEY}.tgz"
+
+if [ "$SKIP_IF_EXISTS" = true ];then
+  BUCKET_FILE="$BUCKET/$KEY.tgz"
+  FILE_LS=$(gsutil ls "$BUCKET_FILE")
+  if [ "$FILE_LS" == "$BUCKET_FILE" ];then
+    echo "Cache file exists, exiting save_cache without over-writing cache file."
+    exit 0
+  fi
+fi
 
 echo "Compressing cache to ${CACHE_FILE}..."
 tar cpzf "$CACHE_FILE" ${PATHS[@]} -P


### PR DESCRIPTION
**Problem this PR solves:** Certain types of builds will not change the cache, but `save_cache` will still compress the cache and re-upload it to GCS. This PR provides an option (`-s` or `--skip_if_exists`) to check if the cache file exists in GCS and skips the compress/upload steps if it does exist.

For example, in my node based project I'm caching the `node_modules` directory. If it can be restored from cache, I don't need to run `npm ci` and the `node_modules` directory won't change at all. That directory can be hundreds of megabytes, so the unnecessary compress/upload steps can add up to 30 seconds to the build.

@rharter, wanted to get your feedback on this. If you think it makes sense I can also describe this in the readme file. And any suggestions you have to improve this would be appreciated!