### PR TITLE
Double quote $@ to ensure arguments are forwarded properly

### DIFF
--- a/android/for_branch
+++ b/android/for_branch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Runs the arguments as if they were passed directly to bash if the 
+# Runs the arguments as if they were passed directly to bash if the
 # BRANCH_NAME environment variable matches the branch argument in the
 # first position.
 
@@ -8,8 +8,8 @@ branch=$1
 
 shift
 
-if [ "$BRANCH_NAME" == "$branch" ];then
-  $@
+if [ "$BRANCH_NAME" == "$branch" ]; then
+  "$@"
 else
   echo "Skipping task due to branch name mismatch: wanted $branch, got $BRANCH_NAME."
 fi

--- a/android/run_build
+++ b/android/run_build
@@ -10,4 +10,4 @@ else
   echo "No .buildenv file found at `pwd`"
 fi
 
-$@
+"$@"


### PR DESCRIPTION
`for_branch` is sometimes useful (_it would be great to have native branch filtering per steps, though_).
However, when passing arguments surrounded with quotes that contain spaces, the `$@` splits those arguments per space, which is not ideal.
For instance, the following curl script that sends an APK to HockeyApp only when merging to master would not work:

```
for_branch master curl -H "X-HockeyAppToken: $_TOKEN" $URL
```

We expect:
```
curl
-H
"X-HockeyAppToken: $_TOKEN"
$URL
```

and not:
```
curl
-H
X-HockeyAppToken:
$_TOKEN
$URL
```

This commit adds double quotes to `$@` to ensure arguments are forwarded properly.