### PR TITLE
update kustomize version to current stable v2.0.3

### DIFF
--- a/kustomize/Dockerfile
+++ b/kustomize/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV VER 1.0.11
+ENV VER 2.0.3
 ENV VERSION v${VER}
 
 COPY kustomize.bash /builder/kustomize.bash


### PR DESCRIPTION
Previous Dockerfile was a major version behind
[v2.0.0 release notes](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/version2.0.0.md)