### PR TITLE
set permissions to skaffold bash

### DIFF
--- a/skaffold/Dockerfile
+++ b/skaffold/Dockerfile
@@ -14,5 +14,5 @@ ENV PATH=/builder/bin/:$PATH
 ENV DOCKER_CONFIG=/builder/home/.docker
 
 COPY skaffold.bash /builder/skaffold.bash
-
+RUN chmod +700 /builder/skaffold.bash
 ENTRYPOINT ["/builder/skaffold.bash"]


### PR DESCRIPTION
When I tried to execute skaffold custom builder, it failed with permissions not set on skaffold.bash.