### PR TITLE
Swap ubuntu for alpine for packer image build

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,13 +1,13 @@
-FROM ubuntu
+FROM alpine:3.9
 
 ARG PACKER_VERSION=1.3.1
 ARG PACKER_VERSION_SHA256SUM=254cf648a638f7ebd37dc1b334abe940da30b30ac3465b6e0a9ad59829932fa3
 
-RUN apt-get -y update && apt-get -y install ca-certificates && rm -rf /var/lib/apt/lists/*
-
 COPY packer_${PACKER_VERSION}_linux_amd64.zip .
-RUN echo "${PACKER_VERSION_SHA256SUM} packer_${PACKER_VERSION}_linux_amd64.zip" > checksum && sha256sum -c checksum
-RUN apt-get -y update && apt-get -y install unzip && /usr/bin/unzip packer_${PACKER_VERSION}_linux_amd64.zip
+RUN echo "${PACKER_VERSION_SHA256SUM}  packer_${PACKER_VERSION}_linux_amd64.zip" > checksum && sha256sum -c checksum
+
+RUN /usr/bin/unzip packer_${PACKER_VERSION}_linux_amd64.zip
+
 
 FROM ubuntu
 RUN apt-get -y update && apt-get -y install ca-certificates && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Avoids having to install additional packages to perform some basic tasks
Alpine pinned to 3.9