### PR TITLE
Add zip builder

### DIFF
--- a/zip/Dockerfile
+++ b/zip/Dockerfile
@@ -1,0 +1,6 @@
+FROM launcher.gcr.io/google/ubuntu16_04
+
+RUN apt-get update && \
+    apt-get -y install zip
+
+ENTRYPOINT ["zip"]

--- a/zip/README.md
+++ b/zip/README.md
@@ -1,0 +1,20 @@
+# zip
+
+This is a tool build to simply invoke the
+[`zip`](https://linux.die.net/man/1/zip) command.
+
+Arguments passed to this builder will be passed to `zip` directly.
+
+## Examples
+
+The following examples demonstrate build requests that use this builder.
+
+### Archive and compress caches
+
+This `cloudbuild.yaml` archives and compresses the build cache directories.
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/zip
+  args: ['-r', 'cache.zip', '/root/.gradle']
+```

--- a/zip/cloudbuild.yaml
+++ b/zip/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/zip', '.']
+
+images: ['gcr.io/$PROJECT_ID/zip']


### PR DESCRIPTION
This adds a zip builder, modeled after the tar builder that is already present.

The use case I have is to package up a Google Cloud Function and upload it to an artifact bucket for later deployment (manually at this time).