### PR TITLE
Implemented support for using custom Windows images

### DIFF
--- a/windows-builder/README.md
+++ b/windows-builder/README.md
@@ -29,6 +29,15 @@ steps:
   args: [ '--command', '<command goes here>' ]
 ```
 
+To use a custom Windows image, specify the image URL using the `--image` argument.
+
+```yaml
+steps:
+- name: 'gcr.io/$PROJECT_ID/windows-builder'
+  args: [ '--command', '<command goes here>'
+          '--image', 'projects/$PROJECT_ID/global/images/my-windows-image']
+```
+
 The VM is configured by the builder and then deleted automatically at the end of the build.  Command is executed by `cmd.exe`; in most cases it will be a build script.
 
 To use an existing Windows server instead, also provide the hostname, username and password:

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -13,6 +13,7 @@ var (
 	username = flag.String("username", "", "Username on remote Windows server")
 	password = flag.String("password", "", "Password on remote Windows server")
 	command  = flag.String("command", "", "Command to run on remote Windows server")
+	image    = flag.String("image", "", "Windows image to start the server from")
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 		log.Printf("Connecting to existing host %s", *r.Hostname)
 	} else {
 		ctx := context.Background()
-		s = builder.NewServer(ctx)
+		s = builder.NewServer(ctx, *image)
 		r = &s.Remote
 	}
 	log.Print("Waiting for server to become available")


### PR DESCRIPTION
Firebase team would like to use this builder to package some of our .NET libraries. For that we want the ability to use our own Windows images with .NET Framework and .NET Core pre-installed. This PR makes it possible to specify a custom image for the builder.

I also noticed that Windows images often take longer than 2 minutes to start. So I'm increasing the timeout to 5 minutes as well.