### PR TITLE
Add builder for Esy

### DIFF
--- a/esy/Dockerfile
+++ b/esy/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:12.3-alpine as build
+FROM node:12.4-alpine as build
 
-ARG ESY_VERSION=0.4.3
+ARG ESY_VERSION
 
 ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
 
@@ -25,6 +25,6 @@ RUN apk add --no-cache \
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
-RUN apk add --no-cache glibc-2.28-r0.apk
+RUN apk add --no-cache glibc-2.29-r0.apk
 
 ENTRYPOINT ["/esy/bin/esy"]

--- a/esy/Dockerfile
+++ b/esy/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:12.3-alpine as build
+
+ARG ESY_VERSION=0.4.3
+
+ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
+
+RUN mkdir /esy
+WORKDIR /esy
+
+ENV NPM_CONFIG_PREFIX=/esy
+RUN npm install -g --unsafe-perm esy@${ESY_VERSION}
+
+FROM alpine:3.9
+
+ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
+
+WORKDIR /
+
+COPY --from=build /esy /esy
+
+RUN apk add --no-cache \
+    ca-certificates wget \
+    bash curl perl-utils \
+    git patch gcc g++ musl-dev make m4
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
+RUN apk add --no-cache glibc-2.28-r0.apk
+
+ENTRYPOINT ["/esy/bin/esy"]

--- a/esy/README.md
+++ b/esy/README.md
@@ -1,0 +1,26 @@
+# Esy
+
+This build step invokes `esy` commands in [Google Cloud Build](https://cloud.google.com/cloud-build).
+
+Arguments passed to this builder will be passed to `esy` directly, allowing
+callers to run [any esy command](https://esy.sh/docs/en/commands.html).
+
+## Building this Builder
+
+Before using this builder in a Cloud Build config, it must be built and pushed to the registry in your 
+project. Run the following command in this directory:
+
+```bash
+gcloud builds submit .
+```
+
+> **Advanced builder building:** To specify a particular version of esy, provide the esy version
+> number, and the checksum of that version's zip archive, as Cloud Build [substitutions](https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions):
+>
+> ```bash
+> gcloud builds submit --substitutions=_ESY_VERSION=1.3.5 .
+> ```
+
+## Status
+
+This is unsupported demo-ware. Use at your own risk!

--- a/esy/README.md
+++ b/esy/README.md
@@ -18,7 +18,7 @@ gcloud builds submit .
 > number, and the checksum of that version's zip archive, as Cloud Build [substitutions](https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions):
 >
 > ```bash
-> gcloud builds submit --substitutions=_ESY_VERSION=1.3.5 .
+> gcloud builds submit --substitutions=_ESY_VERSION=0.5.8 .
 > ```
 
 ## Status

--- a/esy/cloudbuild.yaml
+++ b/esy/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/esy:${_ESY_VERSION}',
+        '-t', 'gcr.io/$PROJECT_ID/esy',
+        '--build-arg', 'ESY_VERSION=${_ESY_VERSION}',
+        '.']
+
+substitutions:
+  _ESY_VERSION: 0.4.3
+
+images:
+- 'gcr.io/$PROJECT_ID/esy:latest'
+- 'gcr.io/$PROJECT_ID/esy:$_ESY_VERSION'

--- a/esy/cloudbuild.yaml
+++ b/esy/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
         '.']
 
 substitutions:
-  _ESY_VERSION: 0.4.3
+  _ESY_VERSION: 0.5.8
 
 images:
 - 'gcr.io/$PROJECT_ID/esy:latest'


### PR DESCRIPTION
Esy is a project manager for ReasonML and OCaml.

This PR adds a builder for Esy that can be used like this:
```
steps:
- name: 'gcr.io/project-id/esy'
  args: ['install']
- name: 'gcr.io/project-id/esy'
  args: ['build']
```