### PR TITLE
Fix remote-builder scp command

### DIFF
--- a/remote-builder/run-builder.sh
+++ b/remote-builder/run-builder.sh
@@ -33,12 +33,12 @@ gcloud compute instances create \
 trap cleanup EXIT
 
 gcloud compute scp --compress --recurse \
-       ./ ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \
+       $(pwd) ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \
        --ssh-key-file=${KEYNAME}
 
 gcloud compute ssh --ssh-key-file=${KEYNAME} \
        ${USERNAME}@${INSTANCE_NAME} -- ${COMMAND}
 
 gcloud compute scp --compress --recurse \
-       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} ./ \
+       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} $(pwd) \
        --ssh-key-file=${KEYNAME}

--- a/remote-builder/run-builder.sh
+++ b/remote-builder/run-builder.sh
@@ -40,5 +40,5 @@ gcloud compute ssh --ssh-key-file=${KEYNAME} \
        ${USERNAME}@${INSTANCE_NAME} -- ${COMMAND}
 
 gcloud compute scp --compress --recurse \
-       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} $(pwd) \
+       ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}* $(pwd) \
        --ssh-key-file=${KEYNAME}


### PR DESCRIPTION
remote-builder's scp command uses `./` as the SRC, which errors out:
```
+ gcloud compute scp --compress --recurse ./ admin@builder-67614acd-91ce-4f2a-8cea-9976beccb2e0:/home/admin/workspace/ --ssh-key-file=builder-key
Failed to add the host to the list of known hosts (/builder/home/.ssh/google_compute_known_hosts).

scp: error: unexpected filename: .
ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [1].
+ cleanup
``` 

Replacing `./` with `$(pwd)` fixes the issue:
```
+ gcloud compute scp --compress --recurse /workspace admin@builder-897e6d6f-bffc-4780-818d-5e474b4ac3f6:/home/admin/workspace/ --ssh-key-file=builder-key
Failed to add the host to the list of known hosts (/builder/home/.ssh/google_compute_known_hosts).

+ gcloud compute ssh --ssh-key-file=builder-key admin@builder-897e6d6f-bffc-4780-818d-5e474b4ac3f6 -- ping -c 5 10.90.88.10
```

Also fixed copy back: previous behavior will create a sub directory inside of `/workspace`: `/workspace/workspace`. Now it will place the files correctly into `/workspace`