### PR TITLE
[protoc] Parameterize protoc version|architecture

### DIFF
--- a/protoc/Dockerfile
+++ b/protoc/Dockerfile
@@ -1,16 +1,18 @@
-FROM ubuntu
+FROM ubuntu:19.10
 
-ARG PROTOC_VERSION=3.6.1
-ARG PROTOC_TARGET=linux-x86_64
-ARG ASSET_NAME=protoc-${PROTOC_VERSION}-${PROTOC_TARGET}.zip
+ARG VERS=3.8.0
+ARG ARCH=linux-x86_64
 
-RUN apt-get -qy update && apt-get -qy install python wget unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qy update && \
+    apt-get -qy install wget unzip && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN echo "${PROTOC_VERSION}/${ASSET_NAME}"
+RUN echo "${VERS}-${ARCH}"
 
-RUN wget https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_TARGET}.zip && \
-    unzip ${ASSET_NAME} -d protoc && rm ${ASSET_NAME}
+RUN wget https://github.com/google/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip && \
+    unzip protoc-${VERS}-${ARCH}.zip -d protoc && \
+    rm protoc-${VERS}-${ARCH}.zip
 
 ENV PATH=$PATH:/protoc/bin/
 ENTRYPOINT ["protoc"]
-CMD ["--help]
+CMD ["--help"]

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -1,12 +1,16 @@
+substitutions:
+  _VERS: "3.8.0"
+  _ARCH: linux-x86_64
+
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
-      [
-        'build',
-        '--tag',
-        'gcr.io/$PROJECT_ID/protoc',
-        '--cache-from',
-        'gcr.io/$PROJECT_ID/protoc',
-        '.',
-      ]
-images: ['gcr.io/$PROJECT_ID/protoc']
+    - build
+    - "--build-arg=VERS=${_VERS}"
+    - "--build-arg=ARCH=${_ARCH}"
+    - --tag=gcr.io/${PROJECT_ID}/protoc:${_VERS}-${_ARCH}
+    - --tag=gcr.io/${PROJECT_ID}/protoc:3.8.0-linux-x86_64
+    - "."
+
+images:
+- "gcr.io/${PROJECT_ID}/protoc"


### PR DESCRIPTION
These changes should:

+ Update the protoc version from `3.6.1` to the current release `3.8.0`.
+ Provide a way to more easily build current version|architectures as needed.

To build for a different architecture and version:
```bash
gcloud builds submit . \
--config=cloudbuild.yaml \
--substitutions=_VERS=${VERS},_ARCH=${ARCH} \
--project=${PROJECT}
```

However, one challenge I'm having using this Builder is that `protoc` often depends upon external binaries, e.g. `protoc-gen-go` to produce language (Golang) specific sources. I've not yet worked out how to achieve this using this container image.