### PR TITLE
Fix tar cloudbuild.yaml

### DIFF
--- a/tar/cloudbuild.yaml
+++ b/tar/cloudbuild.yaml
@@ -1,6 +1,10 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/tar', '.']
+  args:
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/tar'
+  - '--file=tar/Dockerfile'
+  - '.'
 
 images: ['gcr.io/$PROJECT_ID/tar']
 tags: ['cloud-builders-community']


### PR DESCRIPTION
Tar was failing to be deployed since the `Dockerfile` could not be located when building the image. This was because the whole `source.tgz` was downloaded and the Dockerfile mentioned in the `cloudbuild.yaml` was not referenced based on the `tar` folder path.