### PR TITLE
Make it possible to specify an arbitrary Terraform version

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG TERRAFORM_VERSION=0.12.6
-ARG TERRAFORM_VERSION_SHA256SUM=6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f
+ARG TERRAFORM_VERSION
+ARG TERRAFORM_VERSION_SHA256SUM
 
 RUN apt-get update && \
     apt-get -y install curl unzip ca-certificates && \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,11 +1,11 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV TERRAFORM_VERSION=0.12.6
-ENV TERRAFORM_VERSION_SHA256SUM=6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f
+ARG TERRAFORM_VERSION=0.12.6
+ARG TERRAFORM_VERSION_SHA256SUM=6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f
 
 RUN apt-get update && \
     apt-get -y install curl unzip ca-certificates && \
-    curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    curl -Ss --fail https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
       > terraform_linux_amd64.zip && \
     echo "${TERRAFORM_VERSION_SHA256SUM} terraform_linux_amd64.zip" > terraform_SHA256SUMS && \
     sha256sum -c terraform_SHA256SUMS --status && \

--- a/terraform/README.markdown
+++ b/terraform/README.markdown
@@ -8,9 +8,15 @@ This builder can be used to run the terraform tool in the GCE. From the Hashicor
 > edited, reviewed, and versioned.
 
 ### Building this builder
-To build this builder, run the following command in this directory.
+To build this builder with the default version, run the following command in this directory.
 ```sh
 $ gcloud builds submit --config=cloudbuild.yaml
+```
+
+To override the builder version for Terraform, run the following command in this directory (make sure to update the version and the SHA256 hash with the desired ones).
+```
+$ gcloud builds submit --config=cloudbuild.yaml \
+  --substitutions=_TERRAFORM_VERSION="0.12.6",_TERRAFORM_VERSION_SHA256SUM="6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f"
 ```
 
 ## Using this builder

--- a/terraform/cloudbuild.yaml
+++ b/terraform/cloudbuild.yaml
@@ -19,3 +19,4 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/terraform:${_TERRAFORM_VERSION}'
   args: ['version']
 images: ['gcr.io/${PROJECT_ID}/terraform:${_TERRAFORM_VERSION}']
+tags: ['cloud-builders-community']

--- a/terraform/cloudbuild.yaml
+++ b/terraform/cloudbuild.yaml
@@ -1,9 +1,21 @@
 # In this directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=cloudbuild.yaml
+substitutions:
+  _TERRAFORM_VERSION: 0.12.6
+  _TERRAFORM_VERSION_SHA256SUM: 6544eb55b3e916affeea0a46fe785329c36de1ba1bdb51ca5239d3567101876f
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/${PROJECT_ID}/terraform', '.']
-- name: 'gcr.io/${PROJECT_ID}/terraform'
+  env:
+  - 'TERRAFORM_VERSION=${_TERRAFORM_VERSION}'
+  - 'TERRAFORM_VERSION_SHA256SUM=${_TERRAFORM_VERSION_SHA256SUM}'
+  args:
+  - build
+  - --build-arg
+  - TERRAFORM_VERSION
+  - --build-arg
+  - TERRAFORM_VERSION_SHA256SUM
+  - --tag=gcr.io/${PROJECT_ID}/terraform:${_TERRAFORM_VERSION}
+  - .
+- name: 'gcr.io/${PROJECT_ID}/terraform:${_TERRAFORM_VERSION}'
   args: ['version']
-images: ['gcr.io/${PROJECT_ID}/terraform']
-tags: ['cloud-builders-community']
+images: ['gcr.io/${PROJECT_ID}/terraform:${_TERRAFORM_VERSION}']


### PR DESCRIPTION
In our environment, we found it useful to have the ability to build container images with arbitrary Terraform versions. To that end, I made the following changes which should allow one to do so.

I also added "-Ss --fail" to the curl command line, so that curl doesn't output progress if everything is working correctly, but do so if there's an error, and fail if necessary. This should produce less garbage output and streamline diagnosing issues. Additionally, the container image is properly tagged with the Terraform version, which allows one to be more explicit about which version should actually be used depending on the use case.

The current implementation allows for the Dockerfile to be used independently from Cloud Build as well.