### PR TITLE
[protoc] fixes: documentation and Dockerfile

### DIFF
--- a/protoc/README.md
+++ b/protoc/README.md
@@ -20,7 +20,7 @@ gcloud builds submit . --config=cloudbuild.yaml
 If you wish to specify a different version or architecture for the build, run the following:
 
 ```bash
-gcloud builds submit . --config=cloudbuild.yaml --substitutions=VERS=${VER},ARCH=${ARCH}
+gcloud builds submit . --config=cloudbuild.yaml --substitutions=_VERS=${VER},_ARCH=${ARCH}
 ```
 
 Where `${VERS}` and `${ARCH}` are defined to contain values for the release and architecture as listed on:

--- a/protoc/README.md
+++ b/protoc/README.md
@@ -27,6 +27,8 @@ Where `${VERS}` and `${ARCH}` are defined to contain values for the release and 
 
 https://github.com/protocolbuffers/protobuf/releases
 
+**NB** Due to inconsistent handling of URLs for release candidates, the build will fail when referencing these ([issue](https://github.com/protocolbuffers/protobuf/issues/6522)).
+
 ## Referencing protoc compiler plugins
 
 It is common to augment `protoc` with language-specific compiler plugins. Here is a list of plugins:

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -9,7 +9,6 @@ steps:
     - "--build-arg=VERS=${_VERS}"
     - "--build-arg=ARCH=${_ARCH}"
     - --tag=gcr.io/${PROJECT_ID}/protoc:${_VERS}-${_ARCH}
-    - --tag=gcr.io/${PROJECT_ID}/protoc:3.8.0-linux-x86_64
     - "."
 
 images:


### PR DESCRIPTION
Fixed a couple of issues with the `protoc` builder:

+ Corrected reference to user-defined substitutions
+ Added caveat wrt the builder failing to build with `protoc` release candidates
+ Removed incorrect static tag from images when built.