### PR TITLE
[cache] Introduce key_fallback option on `cache#restore_cache` builder

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -122,3 +122,15 @@ This `cloudbuild.yaml` restores the files from the compressed cache file identif
   - name: 'cache'
     path: '/cache'
 ```
+
+### Restore a cache with a fallback key
+
+```yaml
+- name: gcr.io/$PROJECT_ID/restore_cache
+  id: restore_cache
+  args: [
+    '--bucket=gs://${_CACHE_BUCKET}',
+    '--key=gradle-$( checksum checksum.txt )',
+    '--key_fallback=gradle-',
+  ]
+```

--- a/cache/README.md
+++ b/cache/README.md
@@ -27,15 +27,18 @@ The `--no-clobber` flag is used to skip creating and uploading the cache to GCS 
 
 All options use the form `--option=value` or `-o=value` so that they look nice in Yaml files.
 
-| Option       | Description                                                      |
-| ------------ | ---------------------------------------------------------------- |
-| -b, --bucket | The cloud storage bucket to download the cache from. [optional]  |
-| -s, --src    | The local directory in which the cache is stored. [optional]     |
-| -k, --key    | The cache key used for this cache file. [optional]           |
+| Option                 | Description                                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| -b,  --bucket          | The cloud storage bucket to download the cache from. [optional]                        |
+| -s,  --src             | The local directory in which the cache is stored. [optional]                           |
+| -k,  --key             | The cache key used for this cache file. [optional]                                     |
+| -kf, --key_fallback    | The cache key fallback pattern to be used if exact cache key is not found. [optional]  |
 
 One of `--bucket` or `--src` parameters are required.  If `--bucket` then the cache file will be downloaded from the provided GCS bucket path.  If `--src` then the cache file will be read from the directory specified on disk.
 
 The key provided by `--key` is used to identify the cache file.
+
+The fallback key pattern provide by `--key_fallback`, will be used to fetch the most recent cache file matching that pattern in case there is a cache miss from the specified `--key`.
 
 ### `checksum` Helper
 

--- a/cache/cloudbuild.yaml
+++ b/cache/cloudbuild.yaml
@@ -9,7 +9,6 @@ steps:
   - '--file=Dockerfile-base'
   - '.'
 
-
 - name: 'gcr.io/cloud-builders/docker'
   id: build_save_cache
   args: 
@@ -20,7 +19,6 @@ steps:
   - '--build-arg=project_id=$PROJECT_ID'
   - '--cache-from=gcr.io/$PROJECT_ID/cache:latest'
   - '.'
-
 
 - name: 'gcr.io/cloud-builders/docker'
   id: build_restore_cache
@@ -126,9 +124,8 @@ steps:
   - name: original
     path: /original
 
-
 substitutions:
-  _VERSION: '1.1'
+  _VERSION: '1.2'
 
 images: 
 - 'gcr.io/$PROJECT_ID/cache:${_VERSION}'

--- a/cache/restore_cache
+++ b/cache/restore_cache
@@ -3,6 +3,7 @@
 BUCKET=""
 SRC_DIR="."
 KEY="cache"
+KEY_FALLBACK_PATTERN=""
 PATHS=()
 
 function print_usage {
@@ -10,9 +11,10 @@ function print_usage {
   echo
   echo "Saves the specified paths to a cache file located in the out directory."
   echo
-  echo "  -b, --bucket   The cloud storage bucket to download the cache from. [optional]"
-  echo "  -s, --src      The local directory in which the cache is stored. [optional]"
-  echo "  -k, --key      The cache key used for this cache file. [optional]"
+  echo "  -b,  --bucket       The cloud storage bucket to download the cache from. [optional]"
+  echo "  -s,  --src          The local directory in which the cache is stored. [optional]"
+  echo "  -k,  --key          The cache key used for this cache file. [optional]"
+  echo "  -kf, --key_fallback The cache key fallback pattern to be used if exact cache key is not found. It will try to find a file based on the pattern specified and will retrieve the most recent one. [optional]"
   echo 
 }
 
@@ -28,6 +30,10 @@ for i in "$@"; do
       ;;
     -k=*|--key=* )
       KEY="${i#*=}"
+      shift
+      ;;
+    -kf=*|--key_fallback=* )
+      KEY_FALLBACK_PATTERN="${i#*=}"
       shift
       ;;
     -h|--help )
@@ -50,23 +56,51 @@ fi
 
 # Evaluate the key string so that bash variables work
 eval "KEY=\"$KEY\""
+eval "KEY_FALLBACK_PATTERN=\"$KEY_FALLBACK_PATTERN\""
 
 if [ -n "${BUCKET}" ];then
-  remote_cache_file="${BUCKET}/${KEY}.tgz"
-  echo "Downloading cache file: ${remote_cache_file}..."
-  gsutil -q cp "${remote_cache_file}" "${SRC_DIR}"
+  REMOTE_CACHE_FILE="${BUCKET}/${KEY}.tgz"
 
-  if [ $? -ne 0 ];then
-    echo "No remote cache file exists for key ${KEY}"
-    exit 0
+  echo "Checking cache file existence for: ${REMOTE_CACHE_FILE}"
+  REMOTE_CACHE_FILE_EXISTENCE=$(gsutil -q stat ${REMOTE_CACHE_FILE}; echo $?)
+
+  # If cache file exists download and decompress it
+  if [ $REMOTE_CACHE_FILE_EXISTENCE -eq 0 ];then
+    echo "Downloading cache file: ${REMOTE_CACHE_FILE}..."
+    gsutil -q cp "${REMOTE_CACHE_FILE}" "${SRC_DIR}"
+
+    CACHE_FILE="${SRC_DIR}/${KEY}.tgz"
+
+    echo "Restoring cache from file ${CACHE_FILE}..."
+    tar xpzf "$CACHE_FILE" -P
+  else
+    # Check if fallback key pattern has been specified
+    if [ -z "${KEY_FALLBACK_PATTERN}" ]; then
+      echo "No fallback key pattern specified. Can not restore cache!"
+      exit 0
+    fi
+
+    # Try to find a fallback file
+    FALLBACK_CACHE_FILE=$(gsutil ls -l $BUCKET/$KEY_FALLBACK_PATTERN** | sort -k 2,2r | grep -m 1 -i "$KEY_FALLBACK_PATTERN" | awk '{print $3}')
+
+    # Check if fallback cache file has been found
+    if [ -z "${FALLBACK_CACHE_FILE}" ]; then
+      echo "No fallback cache file found! Can not restore cache!"
+      exit 0
+    fi
+
+    # Download found fallback cache file
+    echo "Downloading fallback cache file: ${FALLBACK_CACHE_FILE}..."
+    gsutil -q cp "${FALLBACK_CACHE_FILE}" "${SRC_DIR}"
+
+    FALLBACK_CACHE_FILE_NAME=$(echo ${FALLBACK_CACHE_FILE} | awk '{split($0,parts,"/"); print parts[4]}')
+
+    echo "Restoring cache from fallback file ${FALLBACK_CACHE_FILE}..."
+    tar xpzf "$FALLBACK_CACHE_FILE_NAME" -P
   fi
-fi
-
-CACHE_FILE="${SRC_DIR}/${KEY}.tgz"
-
-if [ -f "${CACHE_FILE}" ];then
-  echo "Restoring cache from file ${CACHE_FILE}..."
-  tar xpzf "$CACHE_FILE" -P
-else
-  echo "No cache file for key ${KEY} at ${CACHE_FILE}."
+# If SRC_DIR is specified, restore cache from local file
+elif [ -n "${SRC_DIR}" ]; then
+  LOCAL_CACHE_FILE="${SRC_DIR}/${KEY}.tgz"
+  echo "Restoring from local cache file ${LOCAL_CACHE_FILE}..."
+  tar xpzf "$LOCAL_CACHE_FILE" -P
 fi


### PR DESCRIPTION
# Background
Large projects (like ours for example) utilizing the `cache` builder, can not afford a lot of cache misses in case of a single change to a file modifying the actual cache checksum. Other CI/CD solutions (e.g.: CircleCI) that support out-of-the-box cache save & restoration, support multiple key patterns for cache restoration in case the key is not found.

# Contents of the PR
This PR modifies `restore_cache` script to accept a `key_fallback` option that will be used in case there is a cache miss from the `key` option. 

It also refactors the way `restore_cache` was working in order to rely on file existence checks instead of failed file copy attempt to attest a cache file's existence.

# Usage
Specify `key_fallback` option in `restore_cache` builder in order to use a fallback name pattern. 

Example
```yaml
- name: gcr.io/$PROJECT_ID/restore_cache
  id: restore_cache
  waitFor: ['generate_cache_checksum']
  args: [
    '--bucket=gs://${_CACHE_BUCKET}',
    '--key=gradle-$( checksum checksum.txt )',
    '--key_fallback=gradle-',
  ]
```