### PR TITLE
[envsubst] add an option for SHELL-FORMAT & set globstar on

### DIFF
--- a/envsubst/README.markdown
+++ b/envsubst/README.markdown
@@ -29,12 +29,12 @@ This builder can also accept wildcards! Lets say you have another file called `i
 The planet ${PLANET} is the next one on the solar system!
 ```
 
-You can pass a wildcard, like so:
+You can pass a wildcard (also a globstar wildcard is supported), like so:
 ```yaml
 - id: preprocess-resources
   name: gcr.io/${PROJECT_ID}/envsubst
   env: ["PLANET=Mars"]
-  args: ["*.txt"]
+  args: ["**/*.txt"]
 ```
 
 This builder can also read environment variables from a `.env` file. Let's assume you have another file called `test.env`:
@@ -48,4 +48,25 @@ You can instruct the builder to use this file to get environment variables from,
 - id: preprocess-resources
   name: gcr.io/${PROJECT_ID}/envsubst
   args: ["-e", "test.env", "*.txt"]
+```
+
+To replace only specified variables, use the `-s` option with a SHELL-FORMAT string like:
+
+```yaml
+- id: preprocess-resources
+  name: gcr.io/${PROJECT_ID}/envsubst
+  env: ["SUBSTITUTED=YES"]
+  args: ["-s", "'$${SUBSTITUTED}'", "shellformat.txt"]  #  '$$' is a escape sequence for the Cloud Build substitution.
+```
+
+When `shellformat.txt` content is below,
+
+```
+It is ${SUBSTITUTED}, and it's ${NOT_SUBSTITUTED}.
+```
+
+then the result will be
+
+```
+It is YES, and it's ${NOT_SUBSTITUTED}.
 ```

--- a/envsubst/cloudbuild.yaml
+++ b/envsubst/cloudbuild.yaml
@@ -11,5 +11,18 @@ steps:
 - name: alpine
   entrypoint: sh
   args: ['-c', '[[ "$(cat test.txt)" == "Mars is Red and Neptune is Blue" ]]']
+- name: 'gcr.io/${PROJECT_ID}/envsubst'
+  env: ["MARS_COLOR=Red"]
+  args: ['-e', 'test.env', '-s', "'$${MARS_COLOR} $${NEPTUNE_COLOR}'", '**/test-shellformat.txt']
+- name: alpine
+  args: [cat, 'test-shellformat.txt']
+- name: alpine
+  args: [cat, 'test-globstar/test-shellformat.txt']
+- name: alpine
+  entrypoint: sh
+  args: ['-c', '[[ "$(cat test-shellformat.txt)" == ''Mars is Red, Neptune is Blue and Saturn is $${YELLOW}'' ]]']
+- name: alpine
+  entrypoint: sh
+  args: ['-c', '[[ "$(cat test-globstar/test-shellformat.txt)" == ''Mars is Red, Neptune is Blue and Saturn is $${YELLOW}'' ]]']
 images: ['gcr.io/${PROJECT_ID}/envsubst']
 tags: ['cloud-builders-community']

--- a/envsubst/entrypoint.bash
+++ b/envsubst/entrypoint.bash
@@ -3,11 +3,13 @@
 set -eu -o pipefail
 declare -a files
 files_count=0
+shell_format=
 
 function usage() {
     echo "usage: $0 [-e <env-file1>] file1 [file2...fileN]" >&2
     echo "  -h    show this help screen" >&2
     echo "  -e    add environment variables from this env file (can be specified multiple times)'" >&2
+    echo "  -s    specify shell-format given to envsubst command" >&2
     exit 0
 }
 
@@ -21,6 +23,11 @@ while true; do
         -e|--env)
             [[ -z "${2}" ]] && usage
             export $(grep -v '^#' ${2} | xargs)
+            shift 2
+            ;;
+        -s|--shell-format)
+            [[ -z "${2}" ]] && usage
+            shell_format=${2}
             shift 2
             ;;
         *)
@@ -37,10 +44,12 @@ if [[ ${files_count} == 0 ]]; then
     exit 1
 fi
 
+shopt -s globstar
+
 # Iterate files/wildcards and pre-process them using envsubst
 for f in $(ls ${files[*]}); do
     echo "Pre-processing ${f}..." >&2
-    cat ${f} | envsubst > ${f}.processed
+    cat ${f} | envsubst ${shell_format:+"${shell_format}"} > ${f}.processed
     mv ${f}.processed ${f}
 done
 

--- a/envsubst/test-globstar/test-shellformat.txt
+++ b/envsubst/test-globstar/test-shellformat.txt
@@ -1,0 +1,1 @@
+Mars is ${MARS_COLOR}, Neptune is ${NEPTUNE_COLOR} and Saturn is ${YELLOW}

--- a/envsubst/test-shellformat.txt
+++ b/envsubst/test-shellformat.txt
@@ -1,0 +1,1 @@
+Mars is ${MARS_COLOR}, Neptune is ${NEPTUNE_COLOR} and Saturn is ${YELLOW}


### PR DESCRIPTION
some improvement for the envsubst builder:
* Added `-s` option to specify a SHELL-FORMAT string to `envsubst` command.
* Set globstar on for more flexible file-matching