### PR TITLE
Support regex match for branch name

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -15,9 +15,20 @@ export BUILD_NUM=123
 
 ## Run Only On Specific Branch
 
-Some build steps should only be run if the build is triggered from a specific branch, like running a deployment script when run from the master branch.  This image includes a `for_branch` script that allows you to pass a branch name and, if the branch name matches the current branch, runs the rest of the argments as if they were passed directly to Bash.
+Some build steps should only be run if the build is triggered from a specific branch, like running a deployment script when run from the master branch.  This image includes a `for_branch` script that allows you to pass a regex and, if the regex matches the current branch name, runs the rest of the argments as if they were passed directly to Bash.
 
 In order for the script environment to get the branch name from the Cloud Build environment it must be passed to the step via the `env` parameter.
+
+```yaml
+# Builds a release apk, only for master or dev branches. 
+- name: 'gcr.io/$PROJECT_ID/android:28'
+  id: build_release
+  args: ["for_branch", "(master|dev)", "./gradlew", ":app:assembleRelease"]
+  env:
+  - 'BRANCH_NAME=$BRANCH_NAME'
+```
+
+This step will build release apk only for master or dev branch. 
 
 ```yaml
 # Only deploys to Play Store if we're on the master branch

--- a/android/for_branch
+++ b/android/for_branch
@@ -8,7 +8,7 @@ branch=$1
 
 shift
 
-if [ "$BRANCH_NAME" == "$branch" ]; then
+if [[ $BRANCH_NAME =~ $branch ]]; then
   "$@"
 else
   echo "Skipping task due to branch name mismatch: wanted $branch, got $BRANCH_NAME."


### PR DESCRIPTION
Certain build/test steps would need to be scoped on a branch pattern or multiple branches. So supporting regex in branch name would help configure steps easily. 
For example, if you want create release builds only on master and dev branches, and configure debug builds for feature branches, regex branch pattern would help.

`- args: ['for_branch', '(master|dev)',...]`
`- args: ['for_branch', '(master|dev|feature\/.*)',...]`