### PR TITLE
ng: Parametrize Dockerfile with ARG ng_version

### DIFF
--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/cloud-builders/npm
 
-RUN npm install -g @angular/cli@latest --unsafe-perms
+ARG ng_version=latest
+RUN npm install -g @angular/cli@$ng_version --unsafe-perms
 
 ENTRYPOINT ["ng"]

--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,6 +1,7 @@
-FROM gcr.io/cloud-builders/npm
+FROM gcr.io/cloud-builders/npm:current
 
 ARG ng_version=latest
-RUN npm install -g @angular/cli@$ng_version --unsafe-perms
+RUN npm install -g @angular/cli@$ng_version --unsafe-perms && \
+    ng version
 
 ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_next
+++ b/ng/Dockerfile_next
@@ -1,5 +1,0 @@
-FROM gcr.io/cloud-builders/npm
-
-RUN npm install -g @angular/cli@next --unsafe-perms
-
-ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v1
+++ b/ng/Dockerfile_v1
@@ -1,5 +1,0 @@
-FROM gcr.io/cloud-builders/npm
-
-RUN npm install -g @angular/cli@1.* --unsafe-perms
-
-ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v6
+++ b/ng/Dockerfile_v6
@@ -1,5 +1,0 @@
-FROM gcr.io/cloud-builders/npm
-
-RUN npm install -g @angular/cli@6.* --unsafe-perms
-
-ENTRYPOINT ["ng"]

--- a/ng/Dockerfile_v7
+++ b/ng/Dockerfile_v7
@@ -1,5 +1,0 @@
-FROM gcr.io/cloud-builders/npm
-
-RUN npm install -g @angular/cli@7.* --unsafe-perms
-
-ENTRYPOINT ["ng"]

--- a/ng/README.md
+++ b/ng/README.md
@@ -6,30 +6,35 @@ Arguments passed to this builder will be passed to the `ng` command directly,
 allowing callers to run [any `ng`
 command](https://github.com/angular/angular-cli/wiki#additional-commands/).
 
+
 ## Available builders
 
 For convenience, we have included different versions of the Angular CLI:
-- `gcr.io/cloud-builders/ng:v1`: provides the v1.* legacy branch
-- `gcr.io/cloud-builders/ng:v6`: provides the v6.* branch
-- `gcr.io/cloud-builders/ng:latest`: provides the latest stable branch
-- `gcr.io/cloud-builders/ng`: same as latest
-- `gcr.io/cloud-builders/ng:next`: provides the next unstable branch
+- `gcr.io/$PROJECT_ID/ng:v1`: provides the `v1.*` legacy branch
+- `gcr.io/$PROJECT_ID/ng:v6`: provides the `v6.*` branch
+- `gcr.io/$PROJECT_ID/ng:v7`: provides the `v7.*` branch
+- `gcr.io/$PROJECT_ID/ng:v8`: provides the `v8.*` branch
+- `gcr.io/$PROJECT_ID/ng:latest`: provides the latest stable branch
+- `gcr.io/$PROJECT_ID/ng`: same as `ng:latest`
+- `gcr.io/$PROJECT_ID/ng:next`: provides the next unstable branch
 
-## How to use?
+
+## Getting started
 
 In order to use call one of these builder, simply invoke the builder (and version), for instance:
 
-```
+```yaml
 steps:
-- name: 'gcr.io/$PROJECT_ID/ng:next'
-  args: ['build', '--prod']
+  - name: 'gcr.io/$PROJECT_ID/ng'
+    args: ['build', '--prod']
 ```
 
 Or, if you are maintaining a legacy Angular project:
-```
+
+```yaml
 steps:
-- name: 'gcr.io/$PROJECT_ID/ng:v1'
-  args: ['test', '--sourcemap=false']
+  - name: 'gcr.io/$PROJECT_ID/ng:v1'
+    args: ['test', '--sourcemap=false']
 ```
 
 See the `examples` folder for a complete example.
@@ -39,4 +44,6 @@ See the `examples` folder for a complete example.
 
 To build these builders, run the following command in this directory:
 
-    $ gcloud builds submit . --config=cloudbuild.yaml
+```shell
+$ gcloud builds submit . --config=cloudbuild.yaml
+```

--- a/ng/cloudbuild.yaml
+++ b/ng/cloudbuild.yaml
@@ -1,16 +1,58 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v1', '-f', 'Dockerfile_v1', '.' ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v6', '-f', 'Dockerfile_v6', '.' ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:v7', '-f', 'Dockerfile_v7', '.' ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:latest', '-f', 'Dockerfile', '.' ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng', '-f', 'Dockerfile', '.' ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/ng:next', '-f', 'Dockerfile_next', '.' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng:v1',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=1.*',
+      ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng:v6',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=6.*',
+      ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng:v7',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=7.*',
+      ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng:latest',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=latest',
+      ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=latest',
+      ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build', '.',
+        '--tag=gcr.io/$PROJECT_ID/ng:next',
+        '--file=Dockerfile',
+        '--build-arg', 'ng_version=next',
+      ]
+
 images:
   - 'gcr.io/$PROJECT_ID/ng:v1'
   - 'gcr.io/$PROJECT_ID/ng:v6'
@@ -18,4 +60,5 @@ images:
   - 'gcr.io/$PROJECT_ID/ng:latest'
   - 'gcr.io/$PROJECT_ID/ng'
   - 'gcr.io/$PROJECT_ID/ng:next'
+
 tags: ['cloud-builders-community']

--- a/ng/cloudbuild.yaml
+++ b/ng/cloudbuild.yaml
@@ -30,16 +30,16 @@ steps:
     args:
       [
         'build', '.',
-        '--tag=gcr.io/$PROJECT_ID/ng:latest',
+        '--tag=gcr.io/$PROJECT_ID/ng:v8',
         '--file=Dockerfile',
-        '--build-arg', 'ng_version=latest',
+        '--build-arg', 'ng_version=8.*',
       ]
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
       [
         'build', '.',
-        '--tag=gcr.io/$PROJECT_ID/ng',
+        '--tag=gcr.io/$PROJECT_ID/ng:latest',
         '--file=Dockerfile',
         '--build-arg', 'ng_version=latest',
       ]
@@ -57,8 +57,8 @@ images:
   - 'gcr.io/$PROJECT_ID/ng:v1'
   - 'gcr.io/$PROJECT_ID/ng:v6'
   - 'gcr.io/$PROJECT_ID/ng:v7'
+  - 'gcr.io/$PROJECT_ID/ng:v8'
   - 'gcr.io/$PROJECT_ID/ng:latest'
-  - 'gcr.io/$PROJECT_ID/ng'
   - 'gcr.io/$PROJECT_ID/ng:next'
 
 tags: ['cloud-builders-community']

--- a/ng/examples/cloudbuild.yaml
+++ b/ng/examples/cloudbuild.yaml
@@ -1,10 +1,17 @@
 steps:
-- name: 'gcr.io/$PROJECT_ID/ng:v1'
-  args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/ng:v6'
-  args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/ng'
-  args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/ng:next'
-  args: ['--version']
+  - name: 'gcr.io/$PROJECT_ID/ng:v1'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng:v6'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng:v7'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng:v8'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng:latest'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng'
+    args: ['version']
+  - name: 'gcr.io/$PROJECT_ID/ng:next'
+    args: ['version']
+
 tags: ['cloud-builders-community']


### PR DESCRIPTION
Now `ng/cloudbuild.yaml` selects the version of `@angular/cli` by
passing args like `--build_arg ng_version=6.*` to `docker build`.
Files ng/Dockerfile_* are no longer needed.

This commit shouldn't cause any changes in behavior.

deleted:    ng/Dockerfile_next
deleted:    ng/Dockerfile_v1
deleted:    ng/Dockerfile_v6
deleted:    ng/Dockerfile_v7