### PR TITLE
Adapting to Helm v3

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v2.14.0
+ARG HELM_VERSION=v2.14.3
 
 COPY helm.bash /builder/helm.bash
 

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v3.0.0-beta.3
+ARG HELM_VERSION=v2.14.0
 
 COPY helm.bash /builder/helm.bash
 

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v2.14.0
+ARG HELM_VERSION=v3.0.0-beta.3
 
 COPY helm.bash /builder/helm.bash
 
@@ -8,8 +8,8 @@ RUN chmod +x /builder/helm.bash && \
   mkdir -p /builder/helm && \
   apt-get update && \
   apt-get install -y curl && \
-  curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
-  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64/helm linux-amd64/tiller && \
+  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64 && \
   rm helm.tar.gz && \
   apt-get --purge -y autoremove && \
   apt-get clean && \

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.14.0', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.14.3', '.']
 
 images: ['gcr.io/$PROJECT_ID/helm']
 tags: ['cloud-builders-community']

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -32,8 +32,13 @@ EOF
     fi
 fi
 
-echo "Running: helm init --client-only"
-helm init --client-only
+# if HELM_VERSION starts with v2, initialize Helm
+if [[ $HELM_VERSION =~ ^v2 ]]; then
+  echo "Running: helm init --client-only"
+  helm init --client-only
+else
+  echo "Skipped `helm init --client-only` because not v2"
+fi
 
 # if GCS_PLUGIN_VERSION is set, install the plugin
 if [[ -n $GCS_PLUGIN_VERSION ]]; then


### PR DESCRIPTION
Helm is now hosted there, https://helm.sh/blog/get-helm-sh/

~Since it's the case since v2.0.0-alpha.5, it is not a breaking change :)~

I guess since Helm v2 also had `tiller` and its folder was also being stripped... that won't work anymore.... maybe it'd be wise to only merge this once v3 is out of beta?