### PR TITLE
Update skaffold latest.

### DIFF
--- a/skaffold/Dockerfile
+++ b/skaffold/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/cloud-builders/kubectl
 RUN mkdir -p /builder/bin && \
   apt-get update && \
   apt-get install -y curl && \
-  curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/releases/v0.37.1/skaffold-linux-amd64 && \
+  curl -sSLo /builder/bin/skaffold https://storage.googleapis.com/skaffold/releases/v0.38.0/skaffold-linux-amd64 && \
   chmod +x /builder/bin/skaffold && \
   apt-get remove --purge -y curl && \
   apt-get --purge -y autoremove && \


### PR DESCRIPTION
updating skaffold's latest release. https://github.com/GoogleContainerTools/skaffold/releases/tag/v0.38.0