### PR TITLE
add --same_trigger_only option to cancelot

### DIFF
--- a/cancelot/README.md
+++ b/cancelot/README.md
@@ -37,6 +37,26 @@ status = "WORKING" AND
 start_time<"[CURRENT_BUILD_START_TIME]"
 ```
 
+If you'd prefer to only cancel builds that were triggered by the same trigger as your current build, use the `--same_trigger_only` option:
+
+```yaml
+steps:
+- name: 'gcr.io/$PROJECT_ID/cancelot'
+  args: [
+    '--current_build_id', '$BUILD_ID',
+    '--branch_name', '$BRANCH_NAME',
+    '--same_trigger_only',
+  ]
+```
+
+When using `--same_trigger_only`, Cancelot will add the following condition to the default filter:
+
+```text
+... AND trigger_id = "[CURRENT_BUILD_TRIGGER_ID]"
+```
+
+`--same_trigger_only` can be helpful if you have multiple repositories connected to the same Cloud Build project or if a single repository has multiple triggers that target the same branch, but with different configurations (e.g., different included / excluded files, tag / branch name patterns, etc).
+
 After successfully fetching the list with the running builds that match the defined criteria, it loops and cancels 
 each one.
 

--- a/cancelot/main.go
+++ b/cancelot/main.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	currentBuildId = flag.String("current_build_id", "", "The current build id, in order to be excluded")
-	branchName     = flag.String("branch_name", "", "BranchName to cancel previous ongoing jobs on")
+	currentBuildID  = flag.String("current_build_id", "", "The current build id, in order to be excluded")
+	branchName      = flag.String("branch_name", "", "BranchName to cancel previous ongoing jobs on")
+	sameTriggerOnly = flag.Bool("same_trigger_only", false, "Only cancel ongoing builds triggered by the same trigger as current_build_id")
 )
 
 func main() {
@@ -20,14 +21,14 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	if *currentBuildId == "" {
-		log.Fatalf("CurrentBuildId must be provided.")
+	if *currentBuildID == "" {
+		log.Fatalf("currentBuildID must be provided.")
 	}
 
 	if *branchName == "" {
 		log.Fatalf("BranchName must be provided.")
 	}
 
-	cancelot.CancelPreviousBuild(ctx, *currentBuildId, *branchName)
+	cancelot.CancelPreviousBuild(ctx, *currentBuildID, *branchName, *sameTriggerOnly)
 	return
 }

--- a/cancelot/test/cloudbuild.yaml
+++ b/cancelot/test/cloudbuild.yaml
@@ -1,8 +1,21 @@
 steps:
+# cancels ongoing builds targeting $BRANCH_NAME regardless of which trigger triggered it
 - name: 'gcr.io/$PROJECT_ID/cancelot'
   args: [
     '--current_build_id', '$BUILD_ID',
     '--branch_name', "$BRANCH_NAME"
   ]
-- name: 'ubuntu'
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['echo', 'done']
+
+# cancels ongoing builds targeting $BRANCH_NAME only if they were triggered by the same trigger as $BUILD_ID
+- name: 'gcr.io/$PROJECT_ID/cancelot'
+  args: [
+    '--current_build_id', '$BUILD_ID',
+    '--branch_name', "$BRANCH_NAME",
+    '--same_trigger_only'
+  ]
+
+- name: 'gcr.io/cloud-builders/gcloud'
   args: ['echo', 'done']


### PR DESCRIPTION
`--same_trigger_only` can be helpful if you have multiple repositories connected to the same Cloud Build project or if a single repository has multiple triggers that target the same branch, but with different configurations (e.g., different included / excluded files, tag / branch name patterns, etc)