### PR TITLE
Bump Hugo version to 0.58.3

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.57.2
+ENV HUGO_VERSION=0.58.3
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/base


### PR DESCRIPTION
Release: https://github.com/gohugoio/hugo/releases/tag/v0.58.3