### PR TITLE
Add cloudbuild pipeline and docker image for velero

### DIFF
--- a/velero/.gitignore
+++ b/velero/.gitignore
@@ -1,0 +1,1 @@
+velero-*-linux-amd64.tar.gz

--- a/velero/Dockerfile
+++ b/velero/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.10
+
+ARG VELERO_VERSION
+ARG VELERO_VERSION_SHA256SUM
+
+COPY velero-${VELERO_VERSION}-linux-amd64.tar.gz velero-${VELERO_VERSION}-linux-amd64.tar.gz
+RUN echo "${VELERO_VERSION_SHA256SUM}  velero-${VELERO_VERSION}-linux-amd64.tar.gz" > checksum && sha256sum -c checksum
+RUN tar xvf velero-${VELERO_VERSION}-linux-amd64.tar.gz
+
+FROM gcr.io/cloud-builders/gcloud
+
+COPY --from=0 velero-v1.1.0-linux-amd64/velero /usr/bin/velero
+COPY velero.bash /builder/velero.bash
+ENTRYPOINT ["/builder/velero.bash"]

--- a/velero/README.md
+++ b/velero/README.md
@@ -1,0 +1,40 @@
+# [Velero](https://github.com/vmware-tanzu/velero) tool builder
+
+## Using this builder with Google Container Engine
+
+To use this builder, your
+[Cloud Build Service Account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions)
+will need IAM permissions sufficient for the operations you want to perform. For
+typical read-only usage, the "Kubernetes Engine Viewer" role is sufficient. To
+deploy container images on a GKE cluster, the "Kubernetes Engine Developer" role
+is sufficient. Check the
+[GKE IAM page](https://cloud.google.com/kubernetes-engine/docs/concepts/access-control)
+for details.
+
+For most use, kubectl will need to be configured to point to a specific GKE
+cluster. You can configure the cluster by setting environment variables.
+
+    # Set region for regional GKE clusters or Zone for Zonal clusters
+    CLOUDSDK_COMPUTE_REGION=<your cluster's region>
+    or
+    CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+
+    # Name of GKE cluster
+    CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
+
+    # (Optional) Project of GKE Cluster, only if you want velero to authenticate
+    # to a GKE cluster in another project (requires IAM Service Accounts are properly setup)
+    GCLOUD_PROJECT=<destination cluster's GCP project>
+
+Setting the environment variables above will cause this step's `entrypoint` to
+first run a command to fetch cluster credentials as follows.
+
+    gcloud container clusters get-credentials --zone "$CLOUDSDK_COMPUTE_ZONE" "$CLOUDSDK_CONTAINER_CLUSTER"`
+
+Then, `kubectl` and consequently `velero` will have the configuration needed to talk to your GKE cluster.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    gcloud builds submit . --config=cloudbuild.yaml

--- a/velero/cloudbuild.yaml
+++ b/velero/cloudbuild.yaml
@@ -1,0 +1,31 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+substitutions:
+  _VELERO_VERSION: v1.1.0
+  _VELERO_VERSION_SHA256SUM: e87e25488eea87717187ea1091dd0e5e322f3291040613c3c8bc85b60df28f2d
+steps:
+  - name: "gcr.io/cloud-builders/wget"
+    args:
+      [
+        "--quiet",
+        "https://github.com/vmware-tanzu/velero/releases/download/${_VELERO_VERSION}/velero-${_VELERO_VERSION}-linux-amd64.tar.gz",
+      ]
+  - name: "gcr.io/cloud-builders/docker"
+    env:
+      - "VELERO_VERSION=${_VELERO_VERSION}"
+      - "VELERO_VERSION_SHA256SUM=${_VELERO_VERSION_SHA256SUM}"
+    args:
+      - build
+      - --build-arg
+      - VELERO_VERSION=${_VELERO_VERSION}
+      - --build-arg
+      - VELERO_VERSION_SHA256SUM=${_VELERO_VERSION_SHA256SUM}
+      - --tag
+      - gcr.io/${PROJECT_ID}/velero:${_VELERO_VERSION}
+      - --tag
+      - gcr.io/${PROJECT_ID}/velero:latest
+      - .
+images:
+  - "gcr.io/${PROJECT_ID}/velero:${_VELERO_VERSION}"
+  - "gcr.io/${PROJECT_ID}/velero:latest"
+tags: ["cloud-builders-community"]

--- a/velero/examples/cloudbuild-velero-install.yaml
+++ b/velero/examples/cloudbuild-velero-install.yaml
@@ -1,0 +1,12 @@
+steps:
+  - name: "gcr.io/$PROJECT_ID/velero"
+    args:
+      - "install"
+      - "--provider=gcp"
+      - "--bucket=velero-backups"
+      - "--secret-file=credentials.json"
+      - "--wait"
+    env:
+      - "CLOUDSDK_COMPUTE_REGION=europe-west1"
+      - "CLOUDSDK_CONTAINER_CLUSTER=cluster-1"
+tags: ["cloud-builders-community"]

--- a/velero/examples/cloudbuild-velero-version.yaml
+++ b/velero/examples/cloudbuild-velero-version.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: "gcr.io/$PROJECT_ID/velero"
+   args:
+     - "version"
+   env:
+     - "CLOUDSDK_COMPUTE_REGION=europe-west1"
+     - "CLOUDSDK_CONTAINER_CLUSTER=cluster-1"
+tags: ["cloud-builders-community"]

--- a/velero/velero.bash
+++ b/velero/velero.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# If there is no current context, get one.
+if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
+    # This tries to read environment variables. If not set, it grabs from gcloud
+    cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+    region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+    zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+    project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+
+    function var_usage() {
+        cat <<EOF
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
+  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+EOF
+        exit 1
+    }
+
+    [[ -z "$cluster" ]] && var_usage
+    [ ! "$zone" -o "$region" ] && var_usage
+
+    if [ -n "$region" ]; then
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+    else
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+    fi
+fi
+
+echo "Running: velero $@"
+velero "$@"


### PR DESCRIPTION
Velero can be used to backup and migrate Kubernetes applications and their persistent volumes - https://github.com/vmware-tanzu/velero