### PR TITLE
Update cft to v0.0.4, including checking out from the "cloud-foundati…

### DIFF
--- a/cft/Dockerfile
+++ b/cft/Dockerfile
@@ -2,13 +2,13 @@ FROM gcr.io/cloud-builders/gcloud
 
 RUN apt-get update && apt-get -y install make \
     && pip install setuptools \
-    && git clone https://github.com/GoogleCloudPlatform/deploymentmanager-samples \
-    && cd deploymentmanager-samples/ \
-    && cd community/cloud-foundation \
-    && make prerequisites \
+    && git clone https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit \
+    && cd cloud-foundation-toolkit/ \
+    && cd dm \
+    && make cft-prerequisites \
     && make build \
     && make install \
     && cd / \
-    && rm -rf /deploymentmanager-samples
+    && rm -rf /cloud-foundation-toolkit
 
 ENTRYPOINT ["/usr/local/bin/cft"]

--- a/cft/README.md
+++ b/cft/README.md
@@ -4,7 +4,7 @@ This build step invokes `cft` commands in [Google Cloud Build](https://cloud.goo
 
 Arguments passed to this builder will be passed to `cft` directly, allowing
 callers to run [any CFT
-command](https://github.com/GoogleCloudPlatform/deploymentmanager-samples/blob/cloud-foundation/community/cloud-foundation/docs/userguide.md#cli-usage).
+command](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/dm/docs/userguide.md#cli-usage).
 
 See examples in the `examples` subdirectory.
 

--- a/cft/cloudbuild.yaml
+++ b/cft/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
         '--build-arg', 'CFT_VERSION=${_CFT_VERSION}',
         '.']
 substitutions:
-  _CFT_VERSION: 0.0.2
+  _CFT_VERSION: 0.0.4
 
 images:
 - 'gcr.io/$PROJECT_ID/cft:latest'


### PR DESCRIPTION
Update 'cft' Cloud Builder to v0.0.4, including checking out from the "cloud-foundation-toolkit" GitHub repository.