### PR TITLE
Change Hugo to use Hugo extended, bump to 0.59.1

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,7 +1,7 @@
 FROM busybox
-ENV HUGO_VERSION=0.58.3
-RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
+ENV HUGO_VERSION=0.59.1
+RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/cc
 ENTRYPOINT ["/hugo"]
 COPY --from=0 /hugo /


### PR DESCRIPTION
Hugo Extended includes built-in support for processing SASS/SCSS files that are
excluded from the default Hugo build, but official binaries are included as part
of each release.

I originally considered splitting this into a separate `hugo-extended` builder. I chose not to do so because:
* It would be a novelty for this project to have multiple directories for the same software
* Providing the "extended" variant of Hugo by default is a precedent established by `apt` and `brew`
That said, more than happy to take a steer on that one.

Related issue: https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/310