### PR TITLE
helmfile

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -109,6 +109,6 @@ The following options are configurable via environment variables passed to the b
 | GCS_PLUGIN_VERSION | [GCS plugin](https://github.com/nouney/helm-gcs) version to install, optional |
 | HELM_REPO_NAME | External Helm repository name, optional |
 | HELM_REPO_URL | External Helm repo URL, optional |
-| HELMFILE_VERSION | [Helmfile](https://github.com/roboll/helmfile) version to install, optional
+| HELMFILE_VERSION | [Helmfile](https://github.com/roboll/helmfile) version to install, optional (if using helm v3, please use the helmfile builder)
 | TILLERLESS | If true, Tillerless Helm is enabled, optional |
 | TILLER_NAMESPACE | Tiller namespace, optional |

--- a/helmfile/Dockerfile
+++ b/helmfile/Dockerfile
@@ -1,0 +1,27 @@
+FROM gcr.io/cloud-builders/gcloud
+
+ARG HELM_VERSION=v3.0.0-rc.3
+ARG HELMFILE_VERSION=v0.90.8
+
+COPY helmfile.bash /builder/helmfile.bash
+
+# install curl
+RUN apt-get update && \
+  apt-get install -y curl && \
+  apt-get --purge -y autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# install helm, helmfile and helm-diff plugin
+RUN chmod +x /builder/helmfile.bash && \
+  mkdir -p /builder/helmfile && \
+  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
+  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helmfile linux-amd64 && \
+  rm helm.tar.gz && \
+  curl -SsL https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64 > /builder/helmfile/helmfile && \
+  chmod 700 /builder/helmfile/helmfile && \
+  /builder/helmfile/helm plugin install https://github.com/databus23/helm-diff
+
+ENV PATH=/builder/helmfile/:$PATH
+
+ENTRYPOINT ["/builder/helmfile.bash"]

--- a/helmfile/README.md
+++ b/helmfile/README.md
@@ -1,0 +1,69 @@
+# [Helmfile](https://github.com/roboll/helmfile) builder
+
+## Helm version
+
+At this time this builder is only compatible with helm v3. Added backwards functionality with helm v2 can be added in a subsequent PR if desired.
+
+## Using this builder with Google Kubernetes Engine
+
+To use this builder, your
+[Cloud Build Service Account](https://cloud.google.com/cloud-build/docs/securing-builds/set-service-account-permissions)
+will need IAM permissions sufficient for the operations you want to perform. For
+typical read-only usage, the "Kubernetes Engine Viewer" role is sufficient. To
+deploy container images on a GKE cluster, the "Kubernetes Engine Developer" role
+is sufficient. Check the
+[GKE IAM page](https://cloud.google.com/kubernetes-engine/docs/concepts/access-control)
+for details.
+
+For most use, kubectl will need to be configured to point to a specific GKE
+cluster. You can configure the cluster by setting environment variables.
+
+    # Set region for regional GKE clusters or Zone for Zonal clusters
+    CLOUDSDK_COMPUTE_REGION=<your cluster's region>
+    or
+    CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+
+    # Name of GKE cluster
+    CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
+
+    # (Optional) Project of GKE Cluster, only if you want helm to authenticate
+    # to a GKE cluster in another project (requires IAM Service Accounts are properly setup)
+    GCLOUD_PROJECT=<destination cluster's GCP project>
+
+Setting the environment variables above will cause this step's `entrypoint` to
+first run a command to fetch cluster credentials as follows.
+
+    gcloud container clusters get-credentials --zone "$CLOUDSDK_COMPUTE_ZONE" "$CLOUDSDK_CONTAINER_CLUSTER"`
+
+Then, `kubectl` and consequently `helm` and `helmfile` will have the configuration needed to talk to your GKE cluster.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    gcloud builds submit . --config=cloudbuild.yaml
+
+
+You can set the `Helm` and `Helmfile` versions in `cloudbuild.yaml`.
+
+    args: [
+        'build',
+        '--tag=gcr.io/$PROJECT_ID/helm',
+        '--build-arg', 'HELM_VERSION=v3.0.0-rc.3',
+        '--build-arg', 'HELMFILE_VERSION=v0.90.8',
+        '.'
+    ]
+
+## Using Helmfile
+
+
+Check the [examples](examples) folder for examples of using Helm in `Cloud Build` pipelines.
+
+
+## Configuration
+
+The following options are configurable via environment variables passed to the build step in the `env` parameter:
+
+| Option        | Description   |
+| ------------- | ------------- |
+| GCS_PLUGIN_VERSION | [GCS plugin](https://github.com/nouney/helm-gcs) version to install, optional |

--- a/helmfile/cloudbuild.yaml
+++ b/helmfile/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      [
+        "build",
+        "--tag=gcr.io/$PROJECT_ID/helmfile",
+        "--build-arg",
+        "HELM_VERSION=v3.0.0-rc.3",
+        "--build-arg",
+        "HELMFILE_VERSION=v0.90.8",
+        ".",
+      ]
+
+images: ["gcr.io/$PROJECT_ID/helmfile"]
+tags: ["cloud-builders-community"]

--- a/helmfile/examples/diff/cloudbuild.yaml
+++ b/helmfile/examples/diff/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: "gcr.io/$PROJECT_ID/helmfile"
+    args:
+      [
+        "--environment",
+        "environment-name",
+        "--file",
+        "/path/to/state/file",
+        "diff",
+      ]
+    env:
+      - "CLOUDSDK_COMPUTE_ZONE=cluster-zone"
+      - "CLOUDSDK_CONTAINER_CLUSTER=cluster-name"
+tags: ["cloud-builders-community"]

--- a/helmfile/examples/list/cloudbuild.yaml
+++ b/helmfile/examples/list/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: "gcr.io/$PROJECT_ID/helmfile"
+    args:
+      [
+        "--environment",
+        "environment-name",
+        "--file",
+        "/path/to/state/file",
+        "list",
+      ]
+    env:
+      - "CLOUDSDK_COMPUTE_ZONE=cluster-zone"
+      - "CLOUDSDK_CONTAINER_CLUSTER=cluster-name"
+tags: ["cloud-builders-community"]

--- a/helmfile/examples/sync/cloudbuild.yaml
+++ b/helmfile/examples/sync/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: "gcr.io/$PROJECT_ID/helm"
+    args:
+      [
+        "--environment",
+        "environment-name",
+        "--file",
+        "/path/to/state/file",
+        "sync",
+      ]
+    env:
+      - "CLOUDSDK_COMPUTE_ZONE=cluster-zone"
+      - "CLOUDSDK_CONTAINER_CLUSTER=cluster-name"
+tags: ["cloud-builders-community"]

--- a/helmfile/helmfile.bash
+++ b/helmfile/helmfile.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# If there is no current context, get one.
+if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
+    # This tries to read environment variables. If not set, it grabs from gcloud
+    cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+    region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+    zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+    project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+
+    function var_usage() {
+        cat <<EOF
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+  CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
+  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+EOF
+        exit 1
+    }
+
+    [[ -z "$cluster" ]] && var_usage
+    [ ! "$zone" -o "$region" ] && var_usage
+
+    if [ -n "$region" ]; then
+      echo "Running: gcloud config set container/use_v1_api_client false"
+      gcloud config set container/use_v1_api_client false
+      echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+    else
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+    fi
+fi
+
+# if GCS_PLUGIN_VERSION is set, install the plugin
+if [[ -n $GCS_PLUGIN_VERSION ]]; then
+  echo "Installing helm GCS plugin version $GCS_PLUGIN_VERSION "
+  helm plugin install https://github.com/nouney/helm-gcs --version $GCS_PLUGIN_VERSION
+fi
+
+helmfile "$@"
+


### PR DESCRIPTION
It is better to create a seperate builder for helmfile whose entrypoint is helmfile. As it stands today the only way to use helmfile in the helm builder is to first run a /builder/helm.bash command to set up kube context,install helm and so on, and followup with a helmfile command.

Please note: Only support helm v3 for initial version of this builder. wanted to keep the first commit lean. If we need to provide helm v2 backwards compatibility logic lets do it in a seperate PR.