### PR TITLE
Enable versions in helm image tags

### DIFF
--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,6 +1,9 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.14.3', '.']
-
-images: ['gcr.io/$PROJECT_ID/helm']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm:${_HELM_VERSION}', '--tag=gcr.io/$PROJECT_ID/helm:latest', '--build-arg', 'HELM_VERSION=v${_HELM_VERSION}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/helm:${_HELM_VERSION}'
+  - 'gcr.io/$PROJECT_ID/helm:latest'
 tags: ['cloud-builders-community']
+substitutions:
+  _HELM_VERSION: 2.14.3


### PR DESCRIPTION
Add possibility to easily create, version and manage helm image versions using a single cloud build substitution.