### PR TITLE
ko: only authenticate if necessary

### DIFF
--- a/ko/ko.bash
+++ b/ko/ko.bash
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Authenticate
-/builder/kubectl.bash
+# Authenticate with Kubernetes if cluster is provided.
+cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+if [[ -n "$cluster" ]]; then
+  /builder/kubectl.bash
+fi
 
 echo "Running: ko" "$@" >&2
 exec "/ko" "$@"


### PR DESCRIPTION
Only authenticate (via `/builder/kubectl.bash`) if the environment
variable `CLOUDSDK_CONTAINER_CLUSTER` is populated. This is helpful for
when the image is being used to do things other than applying (e.g.,
resolve).