### PR TITLE
Update Angular to use node LTS

### DIFF
--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3
+FROM node:lts
 
 ARG ng_version=latest
 RUN npm install -g @angular/cli@$ng_version --unsafe-perms && \

--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/npm:current
+FROM node:10.16.3
 
 ARG ng_version=latest
 RUN npm install -g @angular/cli@$ng_version --unsafe-perms && \


### PR DESCRIPTION
The minimum for the latest Angular CLI has changed since https://github.com/GoogleCloudPlatform/cloud-builders-community/commit/a9f486c89e24c42e0419ed07bb7d17c0fe69750e but`gcr.io/cloud-builders/npm:current` hasn't been updated and is thus too old. According to the [last update for that project](https://github.com/GoogleCloudPlatform/cloud-builders/pull/411), the recommendation is to use the official `node` images so I changed this to lts. 