### PR TITLE
[slackbot] add `--copy-*` options

### DIFF
--- a/slackbot/README.md
+++ b/slackbot/README.md
@@ -27,6 +27,138 @@ steps:
 ...
 ```
 
+## API
+
+### `build`
+
+_**type**_ `string`
+
+_**description**_ ID of monitored build
+
+_**notes**_ Required
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot
+  args:
+  # ...
+  - --build
+  - 333225b1-b215-4992-9241-d8f4f3197be2
+  # ...
+```
+
+### `webhook`
+
+_**type**_ `string`
+
+_**description**_ Slack webhook URL
+
+_**notes**_ Required
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot
+  args:
+  # ...
+  - --webhook
+  - https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+  # ...
+```
+
+### `mode`
+
+_**type**_ `string`
+
+_**default**_ `"trigger"`
+
+_**description**_ Mode the builder runs in
+
+_**notes**_ Required. Must be one of: `"trigger"`, `"monitor"`
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot
+  args:
+  # ...
+  - --mode
+  - trigger
+  # ...
+```
+
+### `copy-name`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ Copy [`name`](https://cloud.google.com/cloud-build/docs/build-config#name) of slackbot's build step from monitored build to watcher build
+
+_**notes**_ If enabled, the `name` of the slackbot build step name must include `"slackbot"`. If not enabled, watcher build will use `name: gcr.io/$PROJECT_ID/slackbot`.
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot@sha256:5ae97d5e41e8c4c87f30b3766184e4440c7e4092ccebf13a166ee09ecf9891f5
+  args:
+  # ...
+  - --copy-name
+  # ...
+```
+
+### `copy-tags`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ Copy [`tags`](https://cloud.google.com/cloud-build/docs/build-config#tags) from monitored build to watcher build
+
+_**notes**_ If disabled, the watcher build will use `tags: ["slackbot"]`. If enabled, the monitored build's tags will be added to the defaults. In the following example, the resulting values for the watcher build would be `tags: ["slackbot", "e2e"]`.
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot
+  args:
+  # ...
+  - --copy-tags
+  # ...
+
+tags:
+- e2e
+```
+
+### `copy-timeout`
+
+_**type**_ `bool`
+
+_**default**_ `false`
+
+_**description**_ Copy [`timeout`](https://cloud.google.com/cloud-build/docs/build-config#timeout_2) from monitored build to watcher build
+
+_**notes**_ If enabled, watcher build's `timeout` will be set to monitored build's `timeout` (plus a small margin for transient API errors encountered by the watcher). If disabled, watcher build's `timeout` will not be set (i.e., Cloud Build's defaults will apply).
+
+_**example**_
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/slackbot
+  args:
+  # ...
+  - --copy-timeout
+  # ...
+
+timeout: 900s
+```
+
 ## Examples
 
 Examples showing both successful and unsuccessful builds are in the [examples](examples/) directory.

--- a/slackbot/main.go
+++ b/slackbot/main.go
@@ -11,9 +11,12 @@ import (
 )
 
 var (
-	build   = flag.String("build", "", "Build ID being monitored")
-	webhook = flag.String("webhook", "", "Slack webhook URL")
-	mode    = flag.String("mode", "trigger", "Mode the builder runs in")
+	buildId     = flag.String("build", "", "Id of monitored Build")
+	webhook     = flag.String("webhook", "", "Slack webhook URL")
+	mode        = flag.String("mode", "trigger", "Mode the builder runs in")
+	copyName    = flag.Bool("copy-name", false, "Copy name of slackbot's build step from monitored build to watcher build")
+	copyTags    = flag.Bool("copy-tags", false, "Copy tags from monitored build to watcher build")
+	copyTimeout = flag.Bool("copy-timeout", false, "Copy timeout from monitored build to watcher build")
 )
 
 func main() {
@@ -25,21 +28,34 @@ func main() {
 		log.Fatalf("Slack webhook must be provided.")
 	}
 
-	if *build == "" {
+	if *buildId == "" {
 		log.Fatalf("Build ID must be provided.")
+	}
+
+	if *mode == "" {
+		log.Fatalf("Mode must be provided.")
+	}
+
+	if *mode != "trigger" && *mode != "monitor" {
+		log.Fatalf("Mode must be one of: trigger, monitor.")
+	}
+
+	projectId, err := slackbot.GetProject()
+	if err != nil {
+		log.Fatalf("Failed to get project ID: %v", err)
 	}
 
 	if *mode == "trigger" {
 		// Trigger another build to run the monitor.
-		log.Printf("Starting trigger mode for build %s", *build)
-		slackbot.Trigger(ctx, *build, *webhook)
+		log.Printf("Starting trigger mode for build %s", *buildId)
+		slackbot.Trigger(ctx, projectId, *buildId, *webhook, *copyName, *copyTags, *copyTimeout)
 		return
 	}
+
 	if *mode == "monitor" {
 		// Monitor the other build until completion.
-		log.Printf("Starting monitor mode for build %s", *build)
-		slackbot.Monitor(ctx, *build, *webhook)
+		log.Printf("Starting monitor mode for build %s", *buildId)
+		slackbot.Monitor(ctx, projectId, *buildId, *webhook)
 		return
 	}
-	log.Fatalf("Mode must be provided.")
 }

--- a/slackbot/slackbot/cloudbuild.go
+++ b/slackbot/slackbot/cloudbuild.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+	"errors"
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2/google"
@@ -13,7 +14,7 @@ import (
 )
 
 // getProject gets the project ID.
-func getProject() (string, error) {
+func GetProject() (string, error) {
 	// Test if we're running on GCE.
 	if metadata.OnGCE() {
 		// Use the GCE Metadata service.
@@ -47,4 +48,69 @@ func gcbClient(ctx context.Context) *cloudbuild.Service {
 		log.Fatalf("Caught error creating service: %v", err)
 	}
 	return svc
+}
+
+// hasRequiredSlackbotArgs tests a slice of strings (e.g., BuildStep.Args[]) for references to slackbot's required arguments: "--build", "--webhook"
+func hasRequiredSlackbotArgs(args []string) bool {
+	hasBuildArg := false
+	hasWebhookArg := false
+
+	log.Printf("%s", args)
+	for _, arg := range args {
+		if strings.Contains(arg, "--build") {
+			hasBuildArg = true
+			continue
+		}
+
+		if strings.Contains(arg, "--webhook") {
+			hasWebhookArg = true
+			continue
+		}
+
+		// end one iteration (worst case) after both flags have been found
+		if hasBuildArg && hasWebhookArg {
+			break
+		}
+	}
+
+	if !hasBuildArg {
+		return false
+	}
+
+	if !hasWebhookArg {
+		return false
+	}
+
+	return true
+}
+
+// isSlackbotStep tests a given BuildStep to determine whether it appears to be executing slackbot
+func isSlackbotStep(step *cloudbuild.BuildStep) bool {
+	// Step.Name must contain "slackbot"
+	if !strings.Contains(step.Name, "slackbot") {
+		return false
+	}
+
+	// Step.Args must contain slackbot's required flags
+	if !hasRequiredSlackbotArgs(step.Args) {
+		return false
+	}
+
+	return true
+}
+
+// GetSlackbotBuildStep returns the BuildStep for the first slackbot step it finds; if none are found, it returns an error
+func GetSlackbotBuildStep(build *cloudbuild.Build) (step *cloudbuild.BuildStep, err error){
+	for _, s := range build.Steps {
+		if isSlackbotStep(s) {
+			step = s
+			break
+		}
+	}
+
+	if step == nil {
+		err = errors.New("step not found: no slackbot related BuildStep found")
+	}
+
+	return step, err
 }

--- a/slackbot/slackbot/notify.go
+++ b/slackbot/slackbot/notify.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 )
@@ -17,27 +18,41 @@ func Notify(b *cloudbuild.Build, webhook string) {
 	switch b.Status {
 	case "SUCCESS":
 		i = ":white_check_mark:"
-	case "FAILURE", "CANCELLED":
+	case "FAILURE":
 		i = ":x:"
+	case "CANCELLED":
+		i = ":wastebasket:"
+	case "TIMEOUT":
+		i = ":hourglass:"
 	case "STATUS_UNKNOWN", "INTERNAL_ERROR":
 		i = ":interrobang:"
 	default:
 		i = ":question:"
 	}
-	j := fmt.Sprintf(
-		`{"text": "Cloud Build %s complete: %s %s",
-		    "attachments": [
-				{
-					"fallback": "Open build details at %s",
-					"actions": [
-						{
-							"type": "button",
-							"text": "Open details",
-							"url": "%s"
-						}
-					]
-				}
-			]}`, b.Id, i, b.Status, url, url)
+
+	startTime, err := time.Parse(time.RFC3339, b.StartTime)
+	if err != nil {
+		log.Fatalf("Failed to parse Build.StartTime: %v", err)
+	}
+	finishTime, err := time.Parse(time.RFC3339, b.FinishTime)
+	if err != nil {
+		log.Fatalf("Failed to parse Build.FinishTime: %v", err)
+	}
+	buildDuration := finishTime.Sub(startTime).Truncate(time.Second)
+
+	msgFmt := `{
+		"text": "%s build _%s_ after _%s_",
+		"attachments": [{
+			"fallback": "Open build details at %s",
+			"actions": [{
+				"type": "button",
+				"text": "Open details",
+				"url": "%s"
+			}]
+		}]
+	}`
+
+	j := fmt.Sprintf(msgFmt, i, b.Status, buildDuration, url, url)
 
 	r := strings.NewReader(j)
 	resp, err := http.Post(webhook, "application/json", r)

--- a/slackbot/slackbot/trigger.go
+++ b/slackbot/slackbot/trigger.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
+	"strings"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 )
 
 // Trigger starts an independent watcher build.
-func Trigger(ctx context.Context, build string, webhook string) {
+func Trigger(ctx context.Context, projectId string, buildId string, webhook string, copyName bool, copyTags bool, copyTimeout bool) {
 	svc := gcbClient(ctx)
-	b := &cloudbuild.Build{
+	watcherBuild := &cloudbuild.Build{
 		Steps: []*cloudbuild.BuildStep{
 			&cloudbuild.BuildStep{
 				Name: "gcr.io/$PROJECT_ID/slackbot",
 				Args: []string{
-					fmt.Sprintf("--build=%s", build),
+					fmt.Sprintf("--build=%s", buildId),
 					fmt.Sprintf("--webhook=%s", webhook),
 					"--mode=monitor",
 				},
@@ -25,13 +27,50 @@ func Trigger(ctx context.Context, build string, webhook string) {
 		Tags: []string{"slackbot"},
 	}
 
-	project, err := getProject()
-	if err != nil {
-		log.Fatalf("Failed to get project: %v", err)
+	// the following options require loading the monitored build's details
+	if copyName || copyTags || copyTimeout {
+		getMonitoredBuild := svc.Projects.Builds.Get(projectId, buildId)
+		monitoredBuild, err := getMonitoredBuild.Do()
+		if err != nil {
+			log.Fatalf("Failed to get monitored build: %v", err)
+		}
+
+		// replace watcher's BuildStep.Name with the value used by monitored build
+		if copyName {
+			log.Printf("copying monitored build slackbot step name")
+			monitoredBuildSlackbotStep, err := GetSlackbotBuildStep(monitoredBuild)
+			if err != nil {
+				log.Fatalf("Failed to get slackbot step from monitored build: %v", err)
+			}
+			log.Printf("monitored build slackbot step name: %s", monitoredBuildSlackbotStep.Name)
+			watcherBuild.Steps[0].Name = fmt.Sprintf("%s", monitoredBuildSlackbotStep.Name)
+			log.Printf("watcher build slackbot step name: %s", watcherBuild.Steps[0].Name)
+		}
+
+		// append tags used by monitored build to watcher's BuildStep.Tags
+		if copyTags {
+			log.Printf("copying monitored build Tags")
+			log.Printf("monitored build Tags: %s", strings.Join(monitoredBuild.Tags, ", "))
+			watcherBuild.Tags = append(watcherBuild.Tags, monitoredBuild.Tags...)
+			log.Printf("watcher build Tags: %s", strings.Join(watcherBuild.Tags, ", "))
+		}
+
+		// set watcher's BuildStep.Timeout to value used by monitored build + error margin
+		if copyTimeout {
+			log.Printf("copying monitored build Timeout")
+			log.Printf("monitored build Timeout: %s", monitoredBuild.Timeout)
+			monitoredBuildTimeoutDuration, err := time.ParseDuration(monitoredBuild.Timeout)
+			if err != nil {
+				log.Fatalf("Failed to parse duration from monitored build's Timeout: %v", err)
+			}
+			watcherBuildTimeoutDuration := monitorErrorMarginDuration + monitoredBuildTimeoutDuration
+			watcherBuild.Timeout = fmt.Sprintf("%ds", int(watcherBuildTimeoutDuration.Seconds()))
+			log.Printf("watcher build Timeout: %s", watcherBuild.Timeout)
+		}
 	}
 
-	cr := svc.Projects.Builds.Create(project, b)
-	_, err = cr.Do()
+	createWatcherBuild := svc.Projects.Builds.Create(projectId, watcherBuild)
+	_, err := createWatcherBuild.Do()
 	if err != nil {
 		log.Fatalf("Failed to create watcher build: %v", err)
 	} else {


### PR DESCRIPTION
## Summary

Add new flags to support copying configuration details from "monitored" build to "watcher" build.

### `--copy-image`

Description: Copy [`name`](https://cloud.google.com/cloud-build/docs/build-config#name) of slackbot's build step from monitored build to watcher build

Use case: customization of image executed within "watcher" build (helpful for version control in projects that support multiple versions of "slackbot")

### `--copy-tags`

Description: Copy [`tags`](https://cloud.google.com/cloud-build/docs/build-config#tags) from monitored build to watcher build

Use case: customization of tags assigned to "watcher" build (helpful for filtering of builds in projects that use "slackbot" to monitor builds from multiple triggers)

### `--copy-timeout`

Description: Copy [`timeout`](https://cloud.google.com/cloud-build/docs/build-config#timeout_2) from monitored build to watcher build

Use case: customization of timeout configured for "watcher" build (helpful for preventing timeouts of "watcher" build in cases where "monitored" build's timeout has been increased from Cloud Build default)

## Details

### `main.go`

- execute `GetProject` in entrypoint; include result as `projectId` in arguments to `Trigger`, `Monitor`

### `cloudbuild.go`

- rename `getProject` to `GetProject`
- add utility methods to support `--copy-image`

### `monitor.go`

- add `projectId` argument to `Monitor`; remove `getProject` logic
- rename `build` argument to `buildId`
- rename `lc` variable to `getMonitoredBuild`
- rename `b` variable to `monitoredBuild`
- add `tickDuration`, `monitorErrorMarginDuration` constants to support `--copy-timeout`
- include `tickDuration` in polling error log message

### `notify.go`

- add case, icon for `TIMEOUT`
- update icon for `CANCELLED` case
- add `buildDuration` variable, calculation logic
- add `msgFmt` variable
- replace inline format mask string from `j` assignment with reference to `msgFmt`
- update message text to include Build's `status`, `duration`

### `trigger.go`

- add `projectId` argument to `Trigger`; remove `getProject` logic
- rename `build` argument of `Trigger` to `buildId`
- add `copyName`, `copyTags`, `copyTimeout` arguments to `Trigger`
- rename `b` variable to `watcherBuild`
- add logic to support new options; load monitored build details into `monitoredBuild` (if necessary); update `watcherBuild` fields with values from `monitoredBuild` accordingly
- rename `cr` variable to `createWatcherBuild`

### `README.md`

- add `API` section containing flag documentation
