### PR TITLE
Upgrade Puppeteer

### DIFF
--- a/yarn-puppeteer/Dockerfile
+++ b/yarn-puppeteer/Dockerfile
@@ -1,8 +1,7 @@
 ARG NODE_VERSION
 FROM node:$NODE_VERSION-alpine
 
-# Installs latest Chromium (68) package.
-# - freetype and harfbuzz needed for node:9.11.1-alpine
+# Installs latest Chromium (79) package.
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
@@ -10,7 +9,10 @@ RUN apk update && apk upgrade && \
       chromium@edge \
       nss@edge \
       freetype@edge \
+      freetype-dev@edge \
       harfbuzz@edge \
+      ca-certificates@edge \
+      ttf-freefont@edge \
       git
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
@@ -18,10 +20,10 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV JEST_PUPPETEER_CONFIG jest-puppeteer.config.ci.js
 ENV CI true
 
-# Puppeteer v1.9.0 works with Chromium 68.
+# Puppeteer v2.0.0 works with Chromium 79.
 # - This installation of puppeteer will not be used if the web project this cloud builder is used
 #   on installs puppeteer itself. I.e the web project's puppeteer dependency will take precedence.
-RUN yarn add puppeteer@1.9.0
+RUN yarn add puppeteer@2.0.0
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init

--- a/yarn-puppeteer/cloudbuild.yaml
+++ b/yarn-puppeteer/cloudbuild.yaml
@@ -7,78 +7,45 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=8.12.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.12.0'
-  - '.'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'build'
-  - '--build-arg=NODE_VERSION=9.11.1'
-  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
-  - '.'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'build'
-  - '--build-arg=NODE_VERSION=10.13.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.13.0'
-  # 10.13.0 is tagged :latest
+  - '--build-arg=NODE_VERSION=12.14.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
+  # 12.14.1 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=11.1.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-11.1.0'
-  # 11.1.0 is tagged :current
+  - '--build-arg=NODE_VERSION=13.6.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
+  # 13.6.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:current'
   - '.'
-
 # Print for each version
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.12.0'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
-  args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.13.0'
-  args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-11.1.0'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
   args: ['--version']
 
 # Test the cloud builder on the example
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.12.0'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['install']
   dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.12.0'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['test:puppeteer']
   dir: 'examples/hello_world'
 
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
   args: ['install']
   dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
-  args: ['test:puppeteer']
-  dir: 'examples/hello_world'
-
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.13.0'
-  args: ['install']
-  dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.13.0'
-  args: ['test:puppeteer']
-  dir: 'examples/hello_world'
-
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-11.1.0'
-  args: ['install']
-  dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-11.1.0'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
   args: ['test:puppeteer']
   dir: 'examples/hello_world'
 
 images:
 - 'gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
 - 'gcr.io/$PROJECT_ID/yarn-puppeteer:current'
-- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.12.0'
-- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
-- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.13.0'
-- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-11.1.0'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
 - 'gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'
 tags: ['cloud-builders-community']


### PR DESCRIPTION
  * Add support for NodeJS LTS (12) and current (13)
  * Drop support for old versions of NodeJS (8, 9, 10, 11)
  * Upgrade Puppeteer from 1.9.0 to 2.0.0