### PR TITLE
First version with new parameters to execute commands and create wind…

### DIFF
--- a/windows-builder/README.md
+++ b/windows-builder/README.md
@@ -51,6 +51,31 @@ steps:
           '--command', '<command goes here>' ]
 ```
 
+You can also provide the VPC, Subnetwork, Region, and Zone parameters to specify where to create the VM:
+
+```yaml
+steps:
+- name: 'gcr.io/$PROJECT_ID/windows-builder'
+  args: [ '--network', '<network-name>',
+          '--subnetwork', '<subnetwork-name>',
+          '--region', '<region>',
+          '--zone', '<zone>',
+          '--command', '<command goes here>' ]
+```
+
+As the remote copy command provided is very slow if you have a number of files in your workspace, it is also possible to avoid copying the workspace (you can use GCS to copy the workspace instead):
+
+```yaml
+steps:
+- name: 'gcr.io/$PROJECT_ID/windows-builder'
+  args: [ '--network', '<network-name>',
+          '--subnetwork', '<subnetwork-name>',
+          '--region', '<region>',
+          '--zone', '<zone>',
+          '--not-copy-workspace',
+          '--command', '<command goes here>' ]
+```
+
 Your server must support Basic Authentication (username and password) and your network must allow access from the internet on TCP port 5986.  Do not submit plaintext passwords in your build configuration: instead, use [encrypted credentials](https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials) secured with Cloud KMS.  In addition, you must clear up your workspace directory after use, and take care to manage concurrent builds.
 
 ## Examples

--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -24,6 +24,14 @@ type Remote struct {
 	Password *string
 }
 
+type BuilderServer struct {
+	ImageUrl *string
+	VPC *string
+	Subnet *string
+	Region *string
+	Zone *string
+}
+
 // Wait for server to be available.
 func (r *Remote) Wait() error {
 	timeout := time.Now().Add(time.Minute * 5)

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 
 	"./builder"
 )
@@ -11,9 +12,14 @@ import (
 var (
 	hostname = flag.String("hostname", "", "Hostname of remote Windows server")
 	username = flag.String("username", "", "Username on remote Windows server")
-	password = flag.String("password", "", "Password on remote Windows server")
+	password = flag.String("password", os.Getenv("PASSWORD"), "Password on remote Windows server")
 	command  = flag.String("command", "", "Command to run on remote Windows server")
-	image    = flag.String("image", "", "Windows image to start the server from")
+	notCopyWorkspace = flag.Bool("not-copy-workspace", false, "If copy workspace or not")
+	image    = flag.String("image", "windows-cloud/global/images/windows-server-2019-dc-for-containers-v20191210", "Windows image to start the server from")
+	network = flag.String("network", "default", "The VPC name to use when creating the Windows server")
+	subnetwork = flag.String("subnetwork", "default", "The Subnetwork name to use when creating the Windows server")
+	region = flag.String("region", "us-central1", "The region name to use when creating the Windows server")
+	zone = flag.String("zone", "us-central1-f", "The zone name to use when creating the Windows server")
 )
 
 func main() {
@@ -21,6 +27,7 @@ func main() {
 	flag.Parse()
 	var r *builder.Remote
 	var s *builder.Server
+	var bs *builder.BuilderServer
 
 	// Connect to server
 	if (*hostname != "") && (*username != "") && (*password != "") {
@@ -32,7 +39,14 @@ func main() {
 		log.Printf("Connecting to existing host %s", *r.Hostname)
 	} else {
 		ctx := context.Background()
-		s = builder.NewServer(ctx, *image)
+		bs = &builder.BuilderServer{
+			ImageUrl: image,
+			VPC: network,
+			Subnet: subnetwork,
+			Region: region,
+			Zone: zone,
+		}
+		s = builder.NewServer(ctx, bs)
 		r = &s.Remote
 	}
 	log.Print("Waiting for server to become available")
@@ -42,10 +56,12 @@ func main() {
 	}
 
 	// Copy workspace to remote machine
-	log.Print("Copying workspace")
-	err = r.Copy()
-	if err != nil {
-		log.Fatalf("Error copying workspace: %+v", err)
+	if (!*notCopyWorkspace) {
+		log.Print("Copying workspace")
+		err = r.Copy()
+		if err != nil {
+			log.Fatalf("Error copying workspace: %+v", err)
+		}
 	}
 
 	// Execute on remote
@@ -57,7 +73,7 @@ func main() {
 
 	// Shut down server if started
 	if s != nil {
-		err = s.DeleteInstance()
+		err = s.DeleteInstance(bs)
 		if err != nil {
 			log.Fatalf("Failed to shut down instance: %+v", err)
 		}


### PR DESCRIPTION
Hi,

Here at Leroy Merlin Spain we need to compile some solutions that are Microsoft-Only and the only way we found it possible to accomplish the build with Google Cloud Build was using the windows remote cloud-build-step. As we found some difficulties for our deployment (network and regions basically) and we found that the method to copy workspace was very slow, we customized the windows-builder with success and we wanted to share the changes in case they are found useful.

Basically we added the following parameters:

- network
- bubnetwork
- region
- zone
- not-copy-workspace

We also made a very small change to allow the builder to get the password from an env var.

Hope it is useful. Feel free to ask for any change.

Thanks!