### PR TITLE
restore_cache: delete the cache file after extracting it

### DIFF
--- a/cache/restore_cache
+++ b/cache/restore_cache
@@ -73,6 +73,7 @@ if [ -n "${BUCKET}" ];then
 
     echo "Restoring cache from file ${CACHE_FILE}..."
     tar xpzf "$CACHE_FILE" -P
+    rm "$CACHE_FILE"
   else
     # Check if fallback key pattern has been specified
     if [ -z "${KEY_FALLBACK_PATTERN}" ]; then
@@ -97,6 +98,7 @@ if [ -n "${BUCKET}" ];then
 
     echo "Restoring cache from fallback file ${FALLBACK_CACHE_FILE}..."
     tar xpzf "$FALLBACK_CACHE_FILE_NAME" -P
+    rm "$FALLBACK_CACHE_FILE_NAME"
   fi
 # If SRC_DIR is specified, restore cache from local file
 elif [ -n "${SRC_DIR}" ]; then


### PR DESCRIPTION
This was causing issues for me because the gradle publishing plugin we use refuses to publish unless there's a clean git source tree.

Are there use cases where people would want to leave it there? Should I add a `--delete-tarball` (or whatever) flag for this instead? Alternately, I can just add a separate build step to remove the file, but I'm having a hard time imaginging why anyone would need to leave it lying around...