### PR TITLE
[helm] Fix broken `helm init` for V2 + add test

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
 ARG HELM_VERSION=v2.14.3
+ENV HELM_VERSION=$HELM_VERSION
 
 COPY helm.bash /builder/helm.bash
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -112,3 +112,4 @@ The following options are configurable via environment variables passed to the b
 | HELMFILE_VERSION | [Helmfile](https://github.com/roboll/helmfile) version to install, optional (if using helm v3, please use the helmfile builder)
 | TILLERLESS | If true, Tillerless Helm is enabled, optional |
 | TILLER_NAMESPACE | Tiller namespace, optional |
+| SKIP_CLUSTER_CONFIG | If true, doesn't check or fetch GKE cluster config/creds, optional |

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -1,6 +1,11 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/helm:${_HELM_VERSION}', '--tag=gcr.io/$PROJECT_ID/helm:latest', '--build-arg', 'HELM_VERSION=v${_HELM_VERSION}', '.']
+# Sanity Check: make sure basic functionality works
+- name: 'gcr.io/$PROJECT_ID/helm:latest'
+  args: ['version', '--client']
+  env:
+    - SKIP_CLUSTER_CONFIG=true
 images:
   - 'gcr.io/$PROJECT_ID/helm:${_HELM_VERSION}'
   - 'gcr.io/$PROJECT_ID/helm:latest'

--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # If there is no current context, get one.
-if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
+if [[ $(kubectl config current-context 2> /dev/null) == "" && "$SKIP_CLUSTER_CONFIG" != true ]]; then
     # This tries to read environment variables. If not set, it grabs from gcloud
     cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
     region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
@@ -22,13 +22,11 @@ EOF
     [ ! "$zone" -o "$region" ] && var_usage
 
     if [ -n "$region" ]; then
-      echo "Running: gcloud config set container/use_v1_api_client false"
-      gcloud config set container/use_v1_api_client false
-      echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-      gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+      echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+      gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster"
     else
       echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+      gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster"
     fi
 fi
 
@@ -61,12 +59,12 @@ fi
 
 # check if repo values provided then add that repo
 if [[ -n $HELM_REPO_NAME && -n $HELM_REPO_URL ]]; then
-  echo "Adding chart helm repo $HELM_REPO_URL "
+  echo "Adding chart helm repo $HELM_REPO_URL"
   helm repo add $HELM_REPO_NAME $HELM_REPO_URL
 fi
 
 echo "Running: helm repo update"
-helm repo update
+helm repo list && helm repo update || true
 
 
 # if 'TILLERLESS=true' is set, run a local tiller server with the secret backend
@@ -86,8 +84,7 @@ if [ "$TILLERLESS" = true ]; then
   if [ "$DEBUG" = true ]; then
       echo "Running: helm $@"
   fi
-  helm "$@"
-  exitCode=$?
+  helm "$@" && exitCode=$? || exitCode=$?
   echo "Stopping local tiller server"
   pkill tiller
   exit $exitCode


### PR DESCRIPTION
The main fix here is adding the HELM_VERSION ENV into the Dockerfile.
The ARG that was already specified is only available at Docker image
build-time, so checking for Helm v2 in the entrypoint script didn't work
properly and never ran a `helm init`

I also added a test step that should catch this in the future (and is
actually specifed as a Contribution Requirement for this repo), plus
made the entrypoint script fail in case of unexpected errors (with the
bash '-e' param).

The new SKIP_CLUSTER_CONFIG env var is used for testing, but also handy
for users that want to run Helm commands that don't need any of that,
for example `helm template`.

I also updated the `gcloud container ...` commands to match the latest
interface. Beta is no longer required.