### PR TITLE
hugo version bump to 0.65.1

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.64.1
+ENV HUGO_VERSION=0.65.0
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/cc

--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.65.0
+ENV HUGO_VERSION=0.65.1
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/cc


### PR DESCRIPTION
Release notes: https://github.com/gohugoio/hugo/releases/tag/v0.65.1