### PR TITLE
windows-builder: change access scope to `cloud-platform`

### DIFF
--- a/windows-builder/builder/builder/gce.go
+++ b/windows-builder/builder/builder/gce.go
@@ -167,7 +167,7 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 						Name: "External NAT",
 					},
 				},
-				Network: prefix + s.projectID + "/global/networks/" + *bs.VPC,
+				Network:    prefix + s.projectID + "/global/networks/" + *bs.VPC,
 				Subnetwork: prefix + s.projectID + "/regions/" + *bs.Region + "/subnetworks/" + *bs.Subnet,
 			},
 		},
@@ -175,8 +175,7 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 			{
 				Email: "default",
 				Scopes: []string{
-					compute.DevstorageFullControlScope,
-					compute.ComputeScope,
+					compute.CloudPlatformScope,
 				},
 			},
 		},
@@ -265,7 +264,7 @@ func (s *Server) setFirewallRule(bs *BuilderServer) error {
 		Direction:    "INGRESS",
 		Name:         "allow-winrm-ingress",
 		SourceRanges: []string{"0.0.0.0/0"},
-		Network: prefix + s.projectID + "/global/networks/" + *bs.VPC,
+		Network:      prefix + s.projectID + "/global/networks/" + *bs.VPC,
 	}
 	_, err = s.service.Firewalls.Insert(s.projectID, firewallRule).Do()
 	if err != nil {


### PR DESCRIPTION
This follows the best practice recommended in the docs:

>A best practice is to set the full cloud-platform access scope on the
instance, then securely limit the service account's API access with
Cloud IAM roles.

https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam