### PR TITLE
windows-builder: use latest Go

### DIFF
--- a/windows-builder/images/go-windows/Dockerfile
+++ b/windows-builder/images/go-windows/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM microsoft/windowsservercore:1809 as builder
+FROM mcr.microsoft.com/windows/servercore:1809 as builder
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows-builder/images/go-windows/build.ps1
+++ b/windows-builder/images/go-windows/build.ps1
@@ -1,20 +1,51 @@
-$projectID = gcloud config get-value project;
+$projectID = gcloud config get-value project
 
-[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls";
-$ProgressPreference = 'SilentlyContinue';
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = "Stop"
 
-echo "Downloading Git 2.18";
-Set-Variable -name GIT_URL -value "https://github.com/git-for-windows/git/releases/download/v2.18.0.windows.1/MinGit-2.18.0-64-bit.zip";
-Invoke-WebRequest -Uri $GIT_URL -OutFile git.zip;
+function Get-GitURL {
+    Invoke-RestMethod -Uri https://api.github.com/repos/git-for-windows/git/releases/latest `
+    | Select-Object -ExpandProperty "assets" `
+    | Where-Object { $_.name -match "^MinGit-\d+\.\d+\.\d+-64-bit.zip$" } `
+    | Select-Object -First 1 -ExpandProperty "browser_download_url"
+}
+$git_url=Get-GitURL
 
-echo "Downloading Go 1.10";
-Set-Variable -name GO_URL -value "https://dl.google.com/go/go1.10.3.windows-386.zip";
-Invoke-WebRequest -Uri $GO_URL -Outfile go.zip;
+Write-Host "Downloading Git ($git_url)"
+Invoke-WebRequest -Uri $git_url -OutFile git.zip
 
-gcloud --quiet auth configure-docker;
+function Get-GoTags {
+    for ($page=0;; $page++) {
+        $resp = Invoke-RestMethod -Uri https://api.github.com/repos/golang/go/tags?page=$page
+        If ($resp.Length -eq 0) {
+            # Ran out of pages, bail.
+            break
+        }
 
-echo "Running Docker build";
-docker build -t gcr.io/$projectID/go-windows .;
+        $resp | Select-Object -Property name `
+        | Foreach-Object { if ($_ -match 'go(1\.\d+\.\d+)') { $matches[1]} }
+    }
+}
+
+$latest_go = Get-GoTags | Sort-Object -Descending {[version] $_} | Select-Object -First 1
+$go_url = "https://dl.google.com/go/go$latest_go.windows-386.zip"
+Write-Host "Downloading Go $latest_go ($go_url)"
+Invoke-WebRequest -Uri $go_url -Outfile go.zip
+
+gcloud --quiet auth configure-docker
+
+Write-Host "Running Docker build"
+docker build -t gcr.io/$projectID/go-windows .
 if ($?) {
-    docker push gcr.io/$projectID/go-windows;
+    docker push gcr.io/$projectID/go-windows
+    if ($?) {
+        Write-Host "Successfully pushed!"
+    } else {
+        Write-Host "Failed to push..."
+        exit 1
+    }
+} else {
+    Write-Host "Failed to build docker image"
+    exit 1
 }

--- a/windows-builder/images/go-windows/cloudbuild.yaml
+++ b/windows-builder/images/go-windows/cloudbuild.yaml
@@ -1,5 +1,6 @@
 steps:
 - name: 'gcr.io/$PROJECT_ID/windows-builder'
-  args: [ '--command', 'powershell.exe -file build.ps1' ]
-timeout: 1200s
+  timeout: 3600s
+  args: [ '--command', 'powershell.exe -file build.ps1']
+timeout: 3600s
 tags: ['cloud-builders-community']


### PR DESCRIPTION
Previously, the version of Go was fixed to an old version. This commit
adds logic to find the latest version of Go instead.