### PR TITLE
Add build trigger name to cloudbuild notify text

### DIFF
--- a/slackbot/slackbot/notify.go
+++ b/slackbot/slackbot/notify.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Notify posts a notification to Slack that the build is complete.
-func Notify(b *cloudbuild.Build, webhook string) {
+func Notify(b *cloudbuild.Build, trigger *cloudbuild.BuildTrigger, webhook string) {
 	url := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds/%s", b.Id)
 	var i string
 	switch b.Status {
@@ -41,7 +41,7 @@ func Notify(b *cloudbuild.Build, webhook string) {
 	buildDuration := finishTime.Sub(startTime).Truncate(time.Second)
 
 	msgFmt := `{
-		"text": "%s build _%s_ after _%s_",
+		"text": "%s *%s* build  _%s_ after _%s_",
 		"attachments": [{
 			"fallback": "Open build details at %s",
 			"actions": [{
@@ -52,7 +52,7 @@ func Notify(b *cloudbuild.Build, webhook string) {
 		}]
 	}`
 
-	j := fmt.Sprintf(msgFmt, i, b.Status, buildDuration, url, url)
+	j := fmt.Sprintf(msgFmt, i, trigger.Name, b.Status, buildDuration, url, url)
 
 	r := strings.NewReader(j)
 	resp, err := http.Post(webhook, "application/json", r)


### PR DESCRIPTION
# what

Cloud Build 's trigger name added to slack message.

# why

It is difficult to know which result was notified when multiple build trigger settings.