### PR TITLE
State tool

### DIFF
--- a/state/Dockerfile
+++ b/state/Dockerfile
@@ -1,0 +1,27 @@
+# Go binaries (ie. State Tool) do not run on a plain alpine image, so we use one with a proper glibc version
+FROM frolvlad/alpine-glibc
+
+# Install State Tool
+RUN wget https://platform.activestate.com/dl/cli/install.sh
+RUN chmod +x ./install.sh
+RUN ./install.sh -n -t /usr/local/bin
+
+# Set up default installation dir for language runtime executables
+# If you use a custom path you will have to do one of the following:
+#  - Override the path here and build a new image
+#  - Set the PATH at runtime
+#  - Use the absolute path, eg. /mytargetpath/bin/python3
+ENV PATH="/workspace/.state/bin:${PATH}"
+
+# Source the API key from build args (optional, only required for private projects)
+ARG ACTIVESTATE_API_KEY
+ENV ACTIVESTATE_API_KEY=$ACTIVESTATE_API_KEY
+
+# Uncomment the following line to deploy your language runtime at build time
+# Replace owner/projectName with your project namespace as detailed in http://docs.activestate.com/platform/state/#usage
+# To use a private project build your image with `--build-arg ACTIVESTATE_API_KEY=<api_key>`. Where <api_key> equals
+# the output of `state export new-api-key gcloud-image`
+#RUN state deploy owner/projectName
+
+# Unset API key as we only need it for running the deployment above and we don't want to bake sensitive data into our image
+ENV ACTIVESTATE_API_KEY=

--- a/state/README.md
+++ b/state/README.md
@@ -45,5 +45,4 @@ settings for these secrets.
    [ActiveState Platform]: https://www.activestate.com/products/platform/
    [Documentation]: http://docs.activestate.com/platform/state/#usage
    [State Tool Secrets]: http://docs.activestate.com/platform/state/start.html#secrets
-   [Secrets Documentation]: http://docs.activestate.com/platform/state/secrets.html
    [Google Secret Manager]: https://console.cloud.google.com/security/secret-manager

--- a/state/README.md
+++ b/state/README.md
@@ -1,0 +1,49 @@
+# State Tool
+
+[State Tool] allows you to install Language Runtime Environments from the [ActiveState Platform].
+For [State Tool] usage reference the ActiveState Platform [Documentation].
+
+This document details the runtime usage, meaning you will deploy the language runtime environment 
+as a step in the cloud build process.
+
+Alternatively you can deploy the language runtime environment when you build the Docker image, which
+should significantly increase your cloud build performance. To do this follow the instructions inside
+the Dockerfile instead.
+
+## Usage
+
+Minimal usage example to deploy a language runtime environment at runtime:
+
+```yaml
+steps:
+- name: gcr.io/$PROJECT_ID/state
+  args: 
+  - state
+  - deploy
+  - owner/projectName
+  - --path=/workspace/.state
+```
+
+Replace `owner/projectName` by your project namespace as detailed in the [Documentation].
+
+ - **Note** - For faster performance you can do this at Docker build time. Read the Dockerfile for more information 
+   on how to do this.
+
+### Private Projects and State Secrets
+
+To use private projects or [State Tool Secrets] you'll need to create two Application Secrets using the 
+[Google Secret Manager].
+
+ - **ACTIVESTATE_API_KEY** - obtained by running `state export new-api-key gcloud`
+ - **ACTIVESTATE_PRIVATE_KEY** - obtained by running `state export private-key` (*only required if you intend to use secrets*)
+ 
+Once created ensure that you add `cloudbuild.gserviceaccount.com` as a `Viewer` under the permission 
+settings for these secrets.
+
+
+   [State Tool]: https://www.activestate.com/products/platform/state-tool/
+   [ActiveState Platform]: https://www.activestate.com/products/platform/
+   [Documentation]: http://docs.activestate.com/platform/state/#usage
+   [State Tool Secrets]: http://docs.activestate.com/platform/state/start.html#secrets
+   [Secrets Documentation]: http://docs.activestate.com/platform/state/secrets.html
+   [Google Secret Manager]: https://console.cloud.google.com/security/secret-manager

--- a/state/cloudbuild.yaml
+++ b/state/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: "gcr.io/cloud-builders/docker"
+  args:
+  - build
+  - --tag=gcr.io/$PROJECT_ID/state
+  - .
+- name: "gcr.io/${PROJECT_ID}/state"
+  args:
+  - state
+  - --version
+images: ["gcr.io/$PROJECT_ID/state"]
+tags: ["cloud-builders-community"]

--- a/state/examples/python-hello-world/README.md
+++ b/state/examples/python-hello-world/README.md
@@ -1,0 +1,29 @@
+# Python Hello World
+
+This demonstrates a simple project for printing a "Hello World!" with a
+Python runtime environment provided through the [ActiveState Platform].
+
+This readme assumes you've built the state docker image using the baked
+in language runtime environment. See the [main readme] for more details.
+
+## Usage
+
+Before you can run this example you'll need to set up a Python3 project
+on the [ActiveState Platform], to do this reference the [Creating Custom Projects]
+documentation. Ensure that you create a "Python3" project and select
+a Linux 64bit platform.
+
+Once you have created your project update the Dockerfile to use the
+namespace for your project rather than the placeholder value.
+
+## Executing Your New Builder
+
+Once configured you should be able to simply run
+
+```
+gcloud builds submit --config=cloudbuild.yaml
+```
+
+   [ActiveState Platform]: https://www.activestate.com/products/platform/
+   [Creating Custom Projects]: https://docs.activestate.com/platform/projects/custom-builds/
+   [main readme]: ../../README.md

--- a/state/examples/python-hello-world/cloudbuild.yaml
+++ b/state/examples/python-hello-world/cloudbuild.yaml
@@ -1,0 +1,8 @@
+# Run Hello-World using an ActiveState Platform Runtime Environment
+#
+# See README.md for invocation instructions.
+steps:
+- name: 'gcr.io/$PROJECT_ID/state'
+  args:
+  - python3
+  - hello.py

--- a/state/examples/python-hello-world/hello.py
+++ b/state/examples/python-hello-world/hello.py
@@ -1,0 +1,1 @@
+print("Hello World!")

--- a/state/examples/state-scripts-secrets/README.md
+++ b/state/examples/state-scripts-secrets/README.md
@@ -1,0 +1,29 @@
+# Python Hello World
+
+This demonstrates a simple project for printing a "Hello World!" with a
+Python runtime environment provided through the [ActiveState Platform].
+
+## Usage
+
+Before you can run this example you'll need to set up a Python3 project
+on the [ActiveState Platform], to do this reference the [Creating Custom Projects]
+documentation. Ensure that you create project that uses a Linux 64bit platform.
+
+Once you have created your project update the Dockerfile and the
+activestate.yaml to use the namespace for your project rather than the
+placeholder value.
+
+This example uses secrets, read the *Private Projects and State Secrets*
+in the [main readme] on how to set up cloud build to use State Secrets.
+
+## Executing Your New Builder
+
+Once configured you should be able to simply run
+
+```
+gcloud builds submit --config=cloudbuild.yaml
+```
+
+   [ActiveState Platform]: https://www.activestate.com/products/platform/
+   [Creating Custom Projects]: https://docs.activestate.com/platform/projects/custom-builds/
+   [main readme]: ../../README.md

--- a/state/examples/state-scripts-secrets/README.md
+++ b/state/examples/state-scripts-secrets/README.md
@@ -1,11 +1,11 @@
-# Python Hello World
+# State Scripts & Secrets
 
-This demonstrates a simple project for printing a "Hello World!" with a
-Python runtime environment provided through the [ActiveState Platform].
+This demonstrates a simple project for using [State Tool Scripts & Secrets]
+on Google Cloud Build.
 
 ## Usage
 
-Before you can run this example you'll need to set up a Python3 project
+Before you can run this example you'll need to set up a project
 on the [ActiveState Platform], to do this reference the [Creating Custom Projects]
 documentation. Ensure that you create project that uses a Linux 64bit platform.
 
@@ -24,6 +24,7 @@ Once configured you should be able to simply run
 gcloud builds submit --config=cloudbuild.yaml
 ```
 
+   [State Tool Scripts & Secrets]: https://docs.activestate.com/platform/state/start.html
    [ActiveState Platform]: https://www.activestate.com/products/platform/
    [Creating Custom Projects]: https://docs.activestate.com/platform/projects/custom-builds/
    [main readme]: ../../README.md

--- a/state/examples/state-scripts-secrets/activestate.yaml
+++ b/state/examples/state-scripts-secrets/activestate.yaml
@@ -1,0 +1,7 @@
+project: https://platform.activestate.com/owner/projectName # Replace with your own namespace
+scripts:
+  - name: example
+    standalone: true
+    value: |
+      echo "Your super secret childhood crush: ${secrets.user.crush}" # Every user has their own value
+      echo "Your secret greeting: ${secrets.project.greeting}"        # Every user on the project shares the value

--- a/state/examples/state-scripts-secrets/cloudbuild.yaml
+++ b/state/examples/state-scripts-secrets/cloudbuild.yaml
@@ -1,0 +1,9 @@
+# Run Hello-World using an ActiveState Platform Runtime Environment
+#
+# See README.md for invocation instructions.
+steps:
+- name: 'gcr.io/$PROJECT_ID/state'
+  args:
+  - state
+  - run
+  - example


### PR DESCRIPTION
This adds a cloud builder that integrates the [State Tool](https://www.activestate.com/products/platform/state-tool/), which allows you to pull in language runtimes from the [ActiveState Platform](https://www.activestate.com/products/platform/).