### PR TITLE
Allow Variable `docker-compose` Versions

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:bionic
 
-ARG version=1.24.0
+ARG DOCKER_COMPOSE_VERSION
 
 # https://docs.docker.com/compose/install/
 RUN \
    apt -y update && \
    apt -y install ca-certificates curl docker.io && \
-   curl -L "https://github.com/docker/compose/releases/download/$version/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+   curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
    chmod +x /usr/local/bin/docker-compose
 
 ENTRYPOINT ["/usr/local/bin/docker-compose"]

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -4,8 +4,9 @@ ARG DOCKER_COMPOSE_VERSION
 
 # https://docs.docker.com/compose/install/
 RUN \
-   apt -y update && \
-   apt -y install ca-certificates curl docker.io && \
+   apt-get -y update && \
+   apt-get -y install ca-certificates curl docker.io && \
+   rm -rf /var/lib/apt/lists/* && \
    curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
    chmod +x /usr/local/bin/docker-compose
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -6,6 +6,23 @@ Arguments passed to this builder will be passed to `docker-compose` directly,
 allowing callers to run [any docker-compose
 command](https://docs.docker.com/compose/reference/overview/).
 
+
+# Setup
+
+To make this cloud builder available in your active Google Cloud project:
+```bash
+cd cloud-builders-community/docker-compose
+gcloud builds submit --config=cloudbuild.yaml .
+```
+
+The build defaults to using the latest version of `docker-compose` at the time of writing: `1.25.5`. To use a different version:
+```bash
+cd cloud-builders-community/docker-compose
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_COMPOSE_VERSION="1.24.0"
+```
+
+You can find a list of releases and their version numbers [here](https://github.com/docker/compose/releases).
+
 ## Examples
 
-See examples in the `examples` subdirectory.
+See provided [hello-world](./examples/hello-world/) example.

--- a/docker-compose/cloudbuild.yaml
+++ b/docker-compose/cloudbuild.yaml
@@ -1,21 +1,22 @@
 # In this directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=cloudbuild.yaml
-
+substitutions:
+  _DOCKER_COMPOSE_VERSION: 1.25.5
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg'
-  - 'version=1.24.0'
+  - 'DOCKER_COMPOSE_VERSION=${_DOCKER_COMPOSE_VERSION}'
   - '-t'
   - 'gcr.io/$PROJECT_ID/docker-compose:latest'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/docker-compose:1.24.0'
+  - 'gcr.io/$PROJECT_ID/docker-compose:${_DOCKER_COMPOSE_VERSION}'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/docker-compose'
   args: ['version']
 
 images:
 - 'gcr.io/$PROJECT_ID/docker-compose:latest'
-- 'gcr.io/$PROJECT_ID/docker-compose:1.24.0'
+- 'gcr.io/$PROJECT_ID/docker-compose:${_DOCKER_COMPOSE_VERSION}'
 tags: ['cloud-builders-community']

--- a/docker-compose/examples/hello-world/README.md
+++ b/docker-compose/examples/hello-world/README.md
@@ -1,6 +1,24 @@
-# Docker-compose example
+# Setup
 
-This `cloudbuild.yaml` invokes a `docker-compose up`:
+To make this cloud builder available in your active Google Cloud project:
+```bash
+cd cloud-builders-community/docker-compose
+gcloud builds submit --config=cloudbuild.yaml .
 ```
+
+The build defaults to using the latest version of `docker-compose` at the time of writing: `1.25.5`. To use a different version:
+```bash
+cd cloud-builders-community/docker-compose
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_COMPOSE_VERSION="1.24.0"
+```
+
+You can find a list of releases and their version numbers [here](https://github.com/docker/compose/releases).
+
+
+# Example Build
+The provided `cloudbuild.yaml` simply invokes `docker-compose up` for a service that says "Hello world".
+
+```bash
+cd cloud-builders-community/docker-compose/examples/hello-world
 gcloud builds submit --config=cloudbuild.yaml .
 ```

--- a/docker-compose/examples/hello-world/README.md
+++ b/docker-compose/examples/hello-world/README.md
@@ -1,20 +1,3 @@
-# Setup
-
-To make this cloud builder available in your active Google Cloud project:
-```bash
-cd cloud-builders-community/docker-compose
-gcloud builds submit --config=cloudbuild.yaml .
-```
-
-The build defaults to using the latest version of `docker-compose` at the time of writing: `1.25.5`. To use a different version:
-```bash
-cd cloud-builders-community/docker-compose
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOCKER_COMPOSE_VERSION="1.24.0"
-```
-
-You can find a list of releases and their version numbers [here](https://github.com/docker/compose/releases).
-
-
 # Example Build
 The provided `cloudbuild.yaml` simply invokes `docker-compose up` for a service that says "Hello world".
 


### PR DESCRIPTION
- Pass `--build-arg DOCKER_COMPOSE_VERSION` to allow build submitter to chose desired version
- Change default docker-compose version to 1.25.5
- Use `apt-get` instead of `apt` in `Dockerfile` for CLI stability guarantee
- Remove `/var/lib/apt/lists/*` to shave about 20 MB from resulting image
- Extend/Update READMEs.