### PR TITLE
updated outdated gem builder

### DIFF
--- a/fastlane/Dockerfile
+++ b/fastlane/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.6.0-alpine
 
 RUN apk add --update --no-cache ruby-dev build-base libxml2-dev libxslt-dev
+RUN gem install bundler:2.1.1
 RUN gem i fastlane
 
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8


### PR DESCRIPTION
Without this current fastlane version fails with the following error:

Step #3: /usr/local/lib/ruby/2.6.0/rubygems/dependency.rb:313:in `to_specs': Could not find 'bundler' (2.1.1) required by your /workspace/android/Gemfile.lock. (Gem::MissingSpecVersionError)
Step #3: To update to the latest version installed on your system, run `bundle update --bundler`.
Step #3: To install the missing version, run `gem install bundler:2.1.1`
Step #3: Checked in 'GEM_PATH=/builder/home/.gem/ruby/2.6.0:/usr/local/lib/ruby/gems/2.6.0:/usr/local/bundle', execute `gem env` for more information
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems/specification.rb:1449:in `block in activate_dependencies'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems/specification.rb:1438:in `each'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems/specification.rb:1438:in `activate_dependencies'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems/specification.rb:1420:in `activate'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems.rb:304:in `block in activate_bin_path'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems.rb:303:in `synchronize'
Step #3: 	from /usr/local/lib/ruby/2.6.0/rubygems.rb:303:in `activate_bin_path'
Step #3: 	from /usr/local/bundle/bin/fastlane:23:in `<main>'

After adding builder:2.1.1 fastlane runs succesfully again.