### PR TITLE
Bump hugo version to v0.70.0

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.65.3
+ENV HUGO_VERSION=0.70.0
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/cc


### PR DESCRIPTION
New hugo [release](https://github.com/gohugoio/hugo/releases/tag/v0.70.0)