### PR TITLE
pulumi: Remove submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pulumi/examples"]
-	path = pulumi/examples
-	url = https://github.com/pulumi/examples


### PR DESCRIPTION
This submodule prevent a direct reference such as:

```
- name: 'gcr.io/cloud-builders/docker'
  args:
  - 'build'
  - '--cache-from=gcr.io/$PROJECT_ID/helm:latest'
  - '--tag=gcr.io/$PROJECT_ID/helm:3'
  - '--build-arg=HELM_VERSION=${_HELM_VERSION}'
  - 'https://github.com/GoogleCloudPlatform/cloud-builders-community.git#a99f207b4b5345e6d2c173b21468c4929de4f767:helm'
```