### PR TITLE
[kustomize] 3.6.1

### DIFF
--- a/kustomize/Dockerfile
+++ b/kustomize/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV VERSION v3.5.4
+ENV VERSION v3.6.1
 
 COPY kustomize.bash /builder/kustomize.bash
 

--- a/kustomize/kustomize.bash
+++ b/kustomize/kustomize.bash
@@ -1,43 +1,41 @@
 #!/bin/bash
 
-# If there is no current context, get one.
-if [[ $(kubectl config current-context 2>/dev/null) == "" || "$FORCE_GET_CREDENTIALS" = true ]]; then
-  # This tries to read environment variables. If not set, it grabs from gcloud
-  cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2>/dev/null)}
-  region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2>/dev/null)}
-  zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2>/dev/null)}
-  project=${GCLOUD_PROJECT:-$(gcloud config get-value core/project 2>/dev/null)}
-
-  function var_usage() {
-    cat <<EOF
-No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+function var_usage() {
+  cat <<EOF
+  No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
   CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
-  CLOUDSDK_COMPUTE_ZONE=<cluster zone> (zonal clusters)
+  CLOUDSDK_COMPUTE_ZONE=<cluster zone>
   CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
 EOF
-    exit 1
-  }
 
-  [[ -z "$cluster" ]] && var_usage
-  [ ! "$zone" -o "$region" ] && var_usage
+  exit 1
+}
 
-  if [ -n "$region" ]; then
-    echo "Running: gcloud config set container/use_v1_api_client false"
-    gcloud config set container/use_v1_api_client false
-    echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-    gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
-  else
-    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
-  fi
+cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2>/dev/null)}
+region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2>/dev/null)}
+zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2>/dev/null)}
+project=${CLOUDSDK_CORE_PROJECT:-$(gcloud config get-value core/project 2>/dev/null)}
+
+[[ -z "$cluster" ]] && var_usage
+[ ! "$zone" -o "$region" ] && var_usage
+
+if [ -n "$region" ]; then
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+else
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
 fi
 
 if [ "$APPLY" = true ]; then
+  KUBECTL_PIPE="kubectl apply -f -"
+
   if [ "$DEBUG" = true ]; then
-    echo "Running: kustomize $@ | kubectl apply -f -"
+    echo "Running: kustomize $@ | $KUBECTL_PIPE"
   fi
 
-  kustomize "$@" | kubectl apply -f -
+  kustomize "$@" | $KUBECTL_PIPE
+
 else
   if [ "$DEBUG" = true ]; then
     echo "Running: kustomize $@"


### PR DESCRIPTION
- upgrade to 3.6.1
- use same context setting as https://github.com/GoogleCloudPlatform/cloud-builders/blob/6b38b4cd944dd76336ccf8a5c9307601101fcd6d/kubectl/kubectl.bash#L23-L43
- factor kubectl apply pipe for `APPLY=true` logic