### PR TITLE
Update protoc builder

### DIFF
--- a/protoc/Dockerfile
+++ b/protoc/Dockerfile
@@ -4,6 +4,8 @@ ARG VERS=3.12.4
 ARG ARCH=linux-x86_64
 
 RUN echo "Building protoc Cloud Builder ${VERS}-${ARCH}" && \
+    apk --update add --no-cache wget unzip && \
+    rm -rf /var/cache/apk/* && \
     wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
     unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && \
     rm "protoc-${VERS}-${ARCH}.zip"

--- a/protoc/Dockerfile
+++ b/protoc/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine:3.12
+FROM debian:buster-slim
 
 ARG VERS=3.12.4
 ARG ARCH=linux-x86_64
 
 RUN echo "Building protoc Cloud Builder ${VERS}-${ARCH}" && \
-    apk --update add --no-cache wget unzip && \
-    rm -rf /var/cache/apk/* && \
+    apt-get update -y && apt-get upgrade -y && \
+    apt-get install wget unzip -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* && \
     wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
     unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && \
     rm "protoc-${VERS}-${ARCH}.zip"

--- a/protoc/Dockerfile
+++ b/protoc/Dockerfile
@@ -1,17 +1,12 @@
-FROM ubuntu:19.10
+FROM alpine:3.12
 
-ARG VERS=3.8.0
+ARG VERS=3.12.4
 ARG ARCH=linux-x86_64
 
-RUN apt-get -qy update && \
-    apt-get -qy install wget unzip && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN echo "${VERS}-${ARCH}"
-
-RUN wget https://github.com/google/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip && \
-    unzip protoc-${VERS}-${ARCH}.zip -d protoc && \
-    rm protoc-${VERS}-${ARCH}.zip
+RUN echo "Building protoc Cloud Builder ${VERS}-${ARCH}" && \
+    wget "https://github.com/google/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
+    unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && \
+    rm "protoc-${VERS}-${ARCH}.zip"
 
 ENV PATH=$PATH:/protoc/bin/
 ENTRYPOINT ["protoc"]

--- a/protoc/Dockerfile
+++ b/protoc/Dockerfile
@@ -4,7 +4,7 @@ ARG VERS=3.12.4
 ARG ARCH=linux-x86_64
 
 RUN echo "Building protoc Cloud Builder ${VERS}-${ARCH}" && \
-    wget "https://github.com/google/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
+    wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERS}/protoc-${VERS}-${ARCH}.zip" && \
     unzip "protoc-${VERS}-${ARCH}.zip" -d protoc && \
     rm "protoc-${VERS}-${ARCH}.zip"
 

--- a/protoc/README.md
+++ b/protoc/README.md
@@ -1,7 +1,6 @@
 # protoc
 
-This tool defines a custom build step that allows the Cloud Build worker to
-run the
+This tool defines a custom build step that allows the Cloud Build worker to run the
 [protocol buffer compiler](https://github.com/protocolbuffers/protobuf), `protoc`.
 
 ## When to use this builder
@@ -11,7 +10,8 @@ The `gcr.io/cloud-builders/protoc` build step should be used when you want to ru
 
 ## Building this builder
 
-You will need to build this Builder and push it to a container registry before you may use it. To build and push to Google Container Registry, run the following command in this directory:
+You will need to build this Builder and push it to a container registry before you may use it. 
+To build and push to Google Container Registry, run the following command in this directory:
 
 ```bash
 gcloud builds submit . --config=cloudbuild.yaml
@@ -27,7 +27,8 @@ Where `${VERS}` and `${ARCH}` are defined to contain values for the release and 
 
 https://github.com/protocolbuffers/protobuf/releases
 
-**NB** Due to inconsistent handling of URLs for release candidates, the build will fail when referencing these ([issue](https://github.com/protocolbuffers/protobuf/issues/6522)).
+**NB** Due to inconsistent handling of URLs for release candidates, the build will fail when 
+referencing these ([issue](https://github.com/protocolbuffers/protobuf/issues/6522)).
 
 ## Referencing protoc compiler plugins
 
@@ -35,19 +36,25 @@ It is common to augment `protoc` with language-specific compiler plugins. Here i
 
 https://github.com/protocolbuffers/protobuf/blob/master/docs/third_party.md
 
-These plugins take the form `protoc-gen-[[NAME]]`. For example, the plugin to generate Golang is called `protoc-gen-go`
+These plugins take the form `protoc-gen-[[NAME]]`. For example, the plugin to generate Golang 
+is called `protoc-gen-go`
 
 The usual command takes the form:
+
 ```bash
 protoc \
 --proto-path=... \
 - --go_out=plugins=grpc:...
 ```
-But this assumes that `protoc-gen-go` is accessible in `${PATH}` and configuring `${PATH}` is challenging across containers.
 
-The solution is to install the compiler plugins either to `/workspace` or using `volumes:` and then reference it using `--plugin`
+But this assumes that `protoc-gen-go` is accessible in `${PATH}` and configuring `${PATH}` 
+is challenging across containers.
+
+The solution is to install the compiler plugins either to `/workspace` or using `volumes:` 
+and then reference it using `--plugin`
 
 E.g.:
+
 ```
 - name: gcr.io/${PROJECT_ID}/protoc
   args:
@@ -56,4 +63,5 @@ E.g.:
   - --go_out=plugins=grpc:...
     - /workspace/protos/my.proto
 ```
+
 In this example, `protoc-gen-go` must have been installed during a previous step into `/workspace/plugins`.

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
     - "--build-arg=VERS=${_VERS}"
     - "--build-arg=ARCH=${_ARCH}"
     - --tag=gcr.io/${PROJECT_ID}/protoc:${_VERS}-${_ARCH}
+    - --tag=gcr.io/${PROJECT_ID}/protoc:latest
     - "."
 
 images:

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
     - "."
 
 images:
-  - "gcr.io/${PROJECT_ID}/protoc:latest"
   - "gcr.io/${PROJECT_ID}/protoc:${_VERS}-${_ARCH}"
+  - "gcr.io/${PROJECT_ID}/protoc:latest"
 
 tags: ['cloud-builders-community']

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
     - "."
 
 images:
-- "gcr.io/${PROJECT_ID}/protoc"
+  - "gcr.io/${PROJECT_ID}/protoc:latest"
+  - "gcr.io/${PROJECT_ID}/protoc:${_VERS}-${_ARCH}"
 
 tags: ['cloud-builders-community']

--- a/protoc/cloudbuild.yaml
+++ b/protoc/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _VERS: "3.8.0"
+  _VERS: "3.12.4"
   _ARCH: linux-x86_64
 
 steps:


### PR DESCRIPTION
In this PR I have updated the `protoc` builder to use the latest v3.12.4 version of the protoc.
Also, I've cleaned up docs and switched the base image from `ubuntu:19.10` to smaller `debian:buster-slim`.

I was considering `alpine`, but its compiler is not compatible with protoc and I don't think the effort of making it work worth it.