### PR TITLE
Fixes trivy image so it works in google cloud build

### DIFF
--- a/trivy/Dockerfile
+++ b/trivy/Dockerfile
@@ -1,3 +1,5 @@
 FROM aquasec/trivy
 
+USER root
+
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
After this commit, aquasecurity/trivy@9c91da8#diff-3254677a7917c6c01f55212f86c57fbf, the trivy image will not have access to the docker socket or cache directory and will not be able to write any scan output due to permissions issues.

Another way I thought of to fix this was to change the user in the build step, but I don't see any documentation for how to do this in google cloud build.

Original error:
```
Step #9 - "scan-pr": Digest: sha256:f3e6959173e96dd1a2c314fb879403d22fc0d8bb1080db95e16e1b45d54d9196
Step #9 - "scan-pr": Status: Downloaded newer image for aquasec/trivy:latest
Step #9 - "scan-pr": docker.io/aquasec/trivy:latest
Step #9 - "scan-pr": 2020-07-30T18:07:10.740Z   FATAL   unable to initialize the cache: failed to create cache dir: mkdir /builder/home/.cache: permission denied
```

Build step to recreate error:
```
  - name: gcr.io/$PROJECT_ID/trivy
    id: scan-pr
    args:
      - image
      - --no-progress
      - gcr.io/$PROJECT_ID/<IMAGE_TO_SCAN>
```