### PR TITLE
Windows builder bug fixes + improvements

### DIFF
--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -190,6 +190,10 @@ func (bs *BuilderServer) GetServiceAccountEmail(projectID string) string {
 }
 
 func (bs *BuilderServer) GetLabelsMap() map[string]string {
+	if *bs.Labels == "" {
+		return nil
+	}
+	
 	var labelsMap map[string]string
 
 	for _, label := range strings.Split(*bs.Labels, ",") {

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -22,6 +22,11 @@ var (
 	subnetwork       = flag.String("subnetwork", "default", "The Subnetwork name to use when creating the Windows server")
 	region           = flag.String("region", "us-central1", "The region name to use when creating the Windows server")
 	zone             = flag.String("zone", "us-central1-f", "The zone name to use when creating the Windows server")
+	labels           = flag.String("labels", "", "List of label KEY=VALUE pairs separated by comma to add when creating the Windows server")
+	machineType      = flag.String("machineType", "", "The machine type to use when creating the Windows server")
+	commandTimeout   = flag.Int("commandTimeout", 5, "The command run timeout in minutes")
+	copyTimeout      = flag.Int("copyTimeout", 5, "The workspace copy timeout in minutes")
+	serviceAccount   = flag.String("serviceAccount", "default", "The service account to use when creating the Windows server")
 )
 
 func main() {
@@ -42,11 +47,14 @@ func main() {
 	} else {
 		ctx := context.Background()
 		bs = &builder.BuilderServer{
-			ImageUrl: image,
-			VPC:      network,
-			Subnet:   subnetwork,
-			Region:   region,
-			Zone:     zone,
+			ImageUrl:       image,
+			VPC:            network,
+			Subnet:         subnetwork,
+			Region:         region,
+			Zone:           zone,
+			Labels:         labels,
+			MachineType:    machineType,
+			ServiceAccount: serviceAccount,
 		}
 		s = builder.NewServer(ctx, bs)
 		r = &s.Remote
@@ -54,31 +62,42 @@ func main() {
 	log.Print("Waiting for server to become available")
 	err := r.Wait()
 	if err != nil {
-		log.Fatalf("Error connecting to server: %+v", err)
+		log.Printf("Error connecting to server: %+v", err)
+		deleteInstanceAndExit(s, bs, 1)
 	}
 
 	r.BucketName = workspaceBucket
 	// Copy workspace to remote machine
 	if !*notCopyWorkspace {
 		log.Print("Copying workspace")
-		err = r.Copy(*workspacePath)
+		err = r.Copy(*workspacePath, *copyTimeout)
 		if err != nil {
-			log.Fatalf("Error copying workspace: %+v", err)
+			log.Printf("Error copying workspace: %+v", err)
+			deleteInstanceAndExit(s, bs, 1)
 		}
 	}
 
 	// Execute on remote
 	log.Printf("Executing command %s", *command)
-	err = r.Run(*command)
+	err = r.Run(*command, *commandTimeout)
 	if err != nil {
-		log.Fatalf("Error executing command: %+v", err)
+		log.Printf("Error executing command: %+v", err)
+		deleteInstanceAndExit(s, bs, 1)
 	}
 
 	// Shut down server if started
+	deleteInstanceAndExit(s, bs, 0)
+}
+
+func deleteInstanceAndExit(s *builder.Server, bs *builder.BuilderServer, exitCode int) {
 	if s != nil {
-		err = s.DeleteInstance(bs)
+		err := s.DeleteInstance(bs)
 		if err != nil {
 			log.Fatalf("Failed to shut down instance: %+v", err)
+		} else {
+			log.Print("Instance shut down successfully")
 		}
 	}
+
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
Windows Builder:
Bug fixes:
1. If command exited with an error (ExitCode != 0) than the step will fail.
2. If Copy or Run command failed the instance will be deleted.
3. Wait operation also checking the Error property after operation is done.

Improvments:
1. Labels: added **labels** optional argument, labels will be added to new instance, similar to gcloud cli.
2. Machine Type: added **machineType** optional argument.
3. Command Timeout: added **commandTimeout** optional argument. default is still 5 minutes.
4. Copy Timeout: added **copyTimeout** optional argument. default is still 5 minutes.
5. Service Account: added **serviceAccount** operation argument. if **serviceAccount** is not an email, will add @$ProjectId.iam.gserviceaccount.com suffix

