### PR TITLE
[kustomize] Add cloudbuild substitutions and sample trigger. Bump version

### DIFF
--- a/kustomize/Dockerfile
+++ b/kustomize/Dockerfile
@@ -1,12 +1,14 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ENV VERSION v3.6.1
+# overridden in cloudbuild.yaml
+ARG VER=v3.8.1
+ENV VERSION ${VER}
 
 COPY kustomize.bash /builder/kustomize.bash
 
 RUN apt-get update && \
   apt-get install -y wget && \
-  wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz && \
+  wget -nv https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz && \
   tar xvzf kustomize_${VERSION}_linux_amd64.tar.gz && \
   mkdir /builder/kustomize && \
   mv kustomize /builder/kustomize/kustomize && \

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -60,7 +60,7 @@ To apply the build yourself, you can use a custom entrypoint, e.g.
   - '-c'
   - |
     gcloud container clusters get-credentials --zone "$$CLOUDSDK_COMPUTE_ZONE" "$$CLOUDSDK_CONTAINER_CLUSTER"
-    kustomize build "overlays/prod" | kubectl apply -f -  
+    kustomize build "overlays/prod" | kubectl apply -f -
   env:
     - 'CLOUDSDK_COMPUTE_ZONE=us-west1'
     - 'CLOUDSDK_CONTAINER_CLUSTER=tf-k8s'
@@ -72,3 +72,15 @@ To apply the build yourself, you can use a custom entrypoint, e.g.
 To build this builder, run the following command in this directory.
 
     $ gcloud builds submit . --config=cloudbuild.yaml
+
+To build with another kustomize version, substitute the version into the submission, e.g.
+
+    $ gcloud builds submit . --config=cloudbuild.yaml --substitutions=_KUSTOMIZE_VERSION=v3.5.4
+
+To trigger an image build from a fork of this repository, configure your cloudbuild trigger with the substituiton
+
+```
+_BUILD_DIRECTORY=kustomize
+```
+
+See sample-trigger.yaml

--- a/kustomize/cloudbuild.yaml
+++ b/kustomize/cloudbuild.yaml
@@ -1,10 +1,29 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "--tag=gcr.io/$PROJECT_ID/kustomize", "."]
+    dir: ${_BUILD_DIRECTORY}
+    args:
+      - build
+      - --build-arg
+      - VER=${_KUSTOMIZE_VERSION}
+      - --tag=gcr.io/$PROJECT_ID/kustomize:${_LATEST_TAG}
+      - --tag=gcr.io/$PROJECT_ID/kustomize:${_KUSTOMIZE_VERSION}
+      - .
+
   - # Verify kustomize has been built correctly
     name: "gcr.io/$PROJECT_ID/kustomize"
     entrypoint: "kustomize"
-    args: ["version"]
+    args:
+      - version
 
-images: ["gcr.io/$PROJECT_ID/kustomize"]
-tags: ["cloud-builders-community"]
+images:
+  - gcr.io/$PROJECT_ID/kustomize:${_LATEST_TAG}
+  - gcr.io/$PROJECT_ID/kustomize:${_KUSTOMIZE_VERSION}
+
+substitutions:
+  _BUILD_DIRECTORY: "./" #set to kustomize to run in a trigger
+  _KUSTOMIZE_VERSION: v3.8.1
+  _LATEST_TAG: latest
+
+tags:
+  - cloud-builders-community
+  - kustomize

--- a/kustomize/sample-trigger.yaml
+++ b/kustomize/sample-trigger.yaml
@@ -1,0 +1,13 @@
+# gcloud beta builds import --source=<filename>
+description: 'Kustomize Image Build: Push to ^master$ branch'
+filename: kustomize/cloudbuild.yaml
+includedFiles:
+- kustomize/*
+name: kustomize-image-build
+github:
+  name: cloud-builders-community
+  owner: <GITHUB_ORG> #TODO
+  push:
+    branch: ^master$
+substitutions:
+  _BUILD_DIRECTORY: kustomize


### PR DESCRIPTION
- bump kustomize version and add as a docker arg
- stop wget printing progress logs
- add version, directory, and tag substitutions to cloudbuild.yaml
- add sample trigger for kustomize
- update kustomize readme with samples for substitutions