### PR TITLE
Added official Google Cloud instructions for building firebase on Cloud Build to ReadMe

### DIFF
--- a/firebase/README.md
+++ b/firebase/README.md
@@ -2,7 +2,7 @@
 
 ## Google Cloud Docs
 
-You can find official Google Cloud steps for this build process [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
+You can find official Google Cloud steps for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 
 #
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -2,9 +2,9 @@
 
 ## Official "Deploying to Firebase" Docs
 
-You can find the official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
-
 This build step invokes `firebase` commands that can be used in [Google Cloud Build](https://cloud.google.com/cloud-build/).
+
+You can find the official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 
 Arguments passed to this builder will be passed to `firebase` directly,
 allowing callers to run [any firebase

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -8,7 +8,6 @@ You can find official Google Cloud steps for this build processor [here](https:/
 
 This build step invokes `firebase` commands that can be used in [Google Cloud Build](https://cloud.google.com/cloud-build/).
 
-
 Arguments passed to this builder will be passed to `firebase` directly,
 allowing callers to run [any firebase
 command](https://firebase.google.com/docs/cli/#command_reference).

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -4,8 +4,6 @@
 
 You can find the official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 
-#
-
 This build step invokes `firebase` commands that can be used in [Google Cloud Build](https://cloud.google.com/cloud-build/).
 
 Arguments passed to this builder will be passed to `firebase` directly,

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -1,6 +1,6 @@
 # firebase
 
-## Google Cloud Docs
+## Official "Deploying to Firebase" Docs
 
 You can find official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -2,7 +2,7 @@
 
 ## Google Cloud Docs
 
-You can find official Google Cloud steps for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
+You can find official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 
 #
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -2,6 +2,8 @@
 
 This build step invokes `firebase` commands that can be used in [Google Cloud Build](https://cloud.google.com/cloud-build/).
 
+Detailed steps can be found at https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase
+
 Arguments passed to this builder will be passed to `firebase` directly,
 allowing callers to run [any firebase
 command](https://firebase.google.com/docs/cli/#command_reference).

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -1,8 +1,13 @@
 # firebase
 
+## Google Cloud Docs
+
+You can find official Google Cloud steps for this build process [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
+
+#
+
 This build step invokes `firebase` commands that can be used in [Google Cloud Build](https://cloud.google.com/cloud-build/).
 
-Detailed steps can be found at https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase
 
 Arguments passed to this builder will be passed to `firebase` directly,
 allowing callers to run [any firebase

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -2,7 +2,7 @@
 
 ## Official "Deploying to Firebase" Docs
 
-You can find official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
+You can find the official Google Cloud guide for this build processor [here](https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase).
 
 #
 


### PR DESCRIPTION
This PR links these awesome instructions to the firebase builder: https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-firebase

This link helps you to enable APIs more easily with those big blue button links :).