### PR TITLE
[envsubst] [kustomize] cloudbuild fixups

### DIFF
--- a/envsubst/cloudbuild.yaml
+++ b/envsubst/cloudbuild.yaml
@@ -2,27 +2,44 @@
 # $ gcloud builds submit . --config=cloudbuild.yaml
 steps:
 - name: 'gcr.io/cloud-builders/docker'
+  dir: ${_BUILD_DIRECTORY}
   args: ['build', '--tag=gcr.io/${PROJECT_ID}/envsubst', '.']
 - name: 'gcr.io/${PROJECT_ID}/envsubst'
+  dir: ${_BUILD_DIRECTORY}
   env: ["MARS_COLOR=Red"]
   args: ['-e', 'test.env', 'test.txt']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   args: [cat, 'test.txt']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   entrypoint: sh
   args: ['-c', '[[ "$(cat test.txt)" == "Mars is Red and Neptune is Blue" ]]']
 - name: 'gcr.io/${PROJECT_ID}/envsubst'
+  dir: ${_BUILD_DIRECTORY}
   env: ["MARS_COLOR=Red"]
   args: ['-e', 'test.env', '-s', "'$${MARS_COLOR} $${NEPTUNE_COLOR}'", '**/test-shellformat.txt']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   args: [cat, 'test-shellformat.txt']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   args: [cat, 'test-globstar/test-shellformat.txt']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   entrypoint: sh
   args: ['-c', '[[ "$(cat test-shellformat.txt)" == ''Mars is Red, Neptune is Blue and Saturn is $${YELLOW}'' ]]']
 - name: alpine
+  dir: ${_BUILD_DIRECTORY}
   entrypoint: sh
   args: ['-c', '[[ "$(cat test-globstar/test-shellformat.txt)" == ''Mars is Red, Neptune is Blue and Saturn is $${YELLOW}'' ]]']
-images: ['gcr.io/${PROJECT_ID}/envsubst']
-tags: ['cloud-builders-community']
+
+images:
+- 'gcr.io/${PROJECT_ID}/envsubst:latest'
+
+tags:
+- 'cloud-builders-community'
+- 'envsubst'
+
+substitutions:
+  _BUILD_DIRECTORY: "./" #set to envsubst to run in a trigger

--- a/kustomize/cloudbuild.yaml
+++ b/kustomize/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
       - .
 
   - # Verify kustomize has been built correctly
-    name: "gcr.io/$PROJECT_ID/kustomize"
+    name: "gcr.io/$PROJECT_ID/kustomize:${_LATEST_TAG}"
     entrypoint: "kustomize"
     args:
       - version


### PR DESCRIPTION
## kustomize
- use the `LATEST_TAG` correctly during smoke test

## envsubst
- allow overriding the build directory, so that cloudbuild triggers can be created directly from a fork of this repository

P.S. if anyone is reading this for feature requests, _please_ consider allowing defaulting the build_dir to something else in the trigger yaml, because this is gross. But it works and most other things about cloudbuild are great, so thanks!

coauthored by: @Faffnir
