### PR TITLE
Fix fallback filename when using a subdirectory

### DIFF
--- a/cache/restore_cache
+++ b/cache/restore_cache
@@ -94,7 +94,7 @@ if [ -n "${BUCKET}" ];then
     echo "Downloading fallback cache file: ${FALLBACK_CACHE_FILE}..."
     gsutil -q cp "${FALLBACK_CACHE_FILE}" "${SRC_DIR}"
 
-    FALLBACK_CACHE_FILE_NAME=$(echo ${FALLBACK_CACHE_FILE} | awk '{split($0,parts,"/"); print parts[4]}')
+    FALLBACK_CACHE_FILE_NAME=$(echo ${FALLBACK_CACHE_FILE} | awk '{n=split($0,parts,"/"); print parts[n]}')
 
     echo "Restoring cache from fallback file ${FALLBACK_CACHE_FILE}..."
     tar xpzf "$FALLBACK_CACHE_FILE_NAME" -P


### PR DESCRIPTION
Note the following change:
```
$ FALLBACK_CACHE_FILE=gs://cloudbuild/gemcache/gems-1174055337-2724941891.tgz
$ echo ${FALLBACK_CACHE_FILE} | awk '{split($0,parts,"/"); print parts[4]}'
gemcache
$ echo ${FALLBACK_CACHE_FILE} | awk '{split($0,parts,"/"); print parts[5]}'
gems-1174055337-2724941891.tgz
$ echo ${FALLBACK_CACHE_FILE} | awk '{n=split($0,parts,"/"); print parts[n]}'
gems-1174055337-2724941891.tgz
$
```