### PR TITLE
Update Sonarqube to Java 11

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update \
 	&& apk upgrade \
 	&& apk add ca-certificates \
 	&& update-ca-certificates \
-	&& apk add --update openjdk8-jre tzdata curl unzip bash \
+	&& apk add --update openjdk11-jre tzdata curl unzip bash \
 	&& rm -rf /var/cache/apk/* \
     && mkdir -p /tmp/sonar-scanner  \
 	&& curl -L --silent ${SONAR_SCANNER_CLI_DOWNLOAD_URL} >  /tmp/sonar-scanner/sonar-scanner-cli-${SONARQUBE_SCANNER_CLI_VERSION}-linux.zip  \


### PR DESCRIPTION
```
The version of Java installed in the scanner environment should be upgraded to at least Java 11 by October 2020. Pre-11 versions of Java are already deprecated and scanners using them will stop functioning after October 2020. This refers specifically to the JDK or JRE installed and used in the context where your SonarCloud scanner analysis tool is running. This may be your local build environment or your CI service. This does not have any impact on the Java version targeted by your project code. You can still analyze Java projects that target versions less than 11.
```

https://sonarcloud.io/documentation/appendices/end-of-support/
https://sonarcloud.io/documentation/appendices/move-analysis-java-11/