### PR TITLE
binauthz not anymore in alpha/beta

### DIFF
--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 RUN apk update && apk upgrade --no-cache
 
-RUN apk add --no-cache docker gnupg bash python3
+RUN apk add --no-cache gnupg bash python3
 
 WORKDIR /work
 ADD create_binauthz_attestation.sh /work

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 RUN apk update && apk upgrade --no-cache
 
-RUN apk add --no-cache gnupg bash python3
+RUN apk add --no-cache docker gnupg bash python3
 
 WORKDIR /work
 ADD create_binauthz_attestation.sh /work

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -1,8 +1,6 @@
-FROM google/cloud-sdk:alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 RUN apk update && apk upgrade --no-cache
-
-RUN gcloud components install alpha beta --quiet
 
 RUN apk add --no-cache docker gnupg bash python3
 

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -4,6 +4,8 @@ RUN apk update && apk upgrade --no-cache
 
 RUN apk add --no-cache gnupg bash python3
 
+RUN apk add --no-cache docker gnupg bash python3
+
 WORKDIR /work
 ADD create_binauthz_attestation.sh /work
 ADD parse_arguments.py /work

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -1,8 +1,8 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
-RUN gcloud components install beta --quiet
-
 RUN apk update && apk upgrade --no-cache
+
+RUN gcloud components install beta --quiet
 
 RUN apk add --no-cache docker gnupg bash python3
 

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
+RUN gcloud components install beta --quiet
+
 RUN apk update && apk upgrade --no-cache
 
 RUN apk add --no-cache docker gnupg bash python3

--- a/binauthz-attestation/Dockerfile
+++ b/binauthz-attestation/Dockerfile
@@ -2,8 +2,6 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 RUN apk update && apk upgrade --no-cache
 
-RUN apk add --no-cache gnupg bash python3
-
 RUN apk add --no-cache docker gnupg bash python3
 
 WORKDIR /work

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -25,7 +25,8 @@ fi
 OUTPUT=$(python3 /work/parse_arguments.py $@)
 declare -A args="($OUTPUT)"
 
-IMAGE_AND_DIGEST="$(gcloud container images describe "${args[artifact_url]}"  --format='get(image_summary.fully_qualified_digest)')"
+docker pull "${args[artifact_url]}"
+IMAGE_AND_DIGEST="$(docker inspect "${args[artifact_url]}" --format='{{index .RepoDigests 0}}')"
 echo "$IMAGE_AND_DIGEST"
 
 if [ -n "${args[pgp_key_fingerprint]}" ]; then

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -52,7 +52,7 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
         --signature-file=./generated_signature.pgp \
         --public-key-id="${args[pgp_key_fingerprint]}"
 else
-    gcloud container binauthz attestations sign-and-create \
+    gcloud beta container binauthz attestations sign-and-create \
         --attestor="${args[attestor]}" \
         --artifact-url="$IMAGE_AND_DIGEST" \
         --keyversion="${args[keyversion]}"

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -34,7 +34,7 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
         die "PGP_SECRET_KEY environment variable is required if providing the PGP signing key through an environment variable. Please consult the documentation for more information."
     fi
 
-    gcloud beta container binauthz create-signature-payload \
+    gcloud container binauthz create-signature-payload \
         --artifact-url="$IMAGE_AND_DIGEST" > binauthz_signature_payload.json
 
     mkdir -p ~/.gnupg
@@ -47,13 +47,13 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
 
     echo -n "$PGP_SECRET_KEY" | gpg2 $COMMON_FLAGS --import
     gpg2 $COMMON_FLAGS --output generated_signature.pgp --local-user "${args[pgp_key_fingerprint]}" --armor --sign binauthz_signature_payload.json
-    gcloud alpha container binauthz attestations create \
+    gcloud container binauthz attestations create \
         --artifact-url="$IMAGE_AND_DIGEST" \
         --attestor="${args[attestor]}" \
         --signature-file=./generated_signature.pgp \
         --public-key-id="${args[pgp_key_fingerprint]}"
 else
-    gcloud alpha container binauthz attestations sign-and-create \
+    gcloud container binauthz attestations sign-and-create \
         --attestor="${args[attestor]}" \
         --artifact-url="$IMAGE_AND_DIGEST" \
         --keyversion="${args[keyversion]}"

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -25,8 +25,7 @@ fi
 OUTPUT=$(python3 /work/parse_arguments.py $@)
 declare -A args="($OUTPUT)"
 
-docker pull "${args[artifact_url]}"
-IMAGE_AND_DIGEST="$(docker inspect "${args[artifact_url]}" --format='{{index .RepoDigests 0}}')"
+IMAGE_AND_DIGEST="$(gcloud container images describe "${args[artifact_url]}"  --format='get(image_summary.fully_qualified_digest)')"
 echo "$IMAGE_AND_DIGEST"
 
 if [ -n "${args[pgp_key_fingerprint]}" ]; then


### PR DESCRIPTION
Updates:
- `gcr.io/google.com/cloudsdktool/cloud-sdk:alpine` as base image instead of `google/cloud-sdk:alpine`
- BinAuthz is GA, not anymore in alpha/beta