### PR TITLE
helmfile: Error out when `helmfile` fails

### DIFF
--- a/helmfile/helmfile.bash
+++ b/helmfile/helmfile.bash
@@ -38,5 +38,5 @@ if [[ -n $GCS_PLUGIN_VERSION ]]; then
   helm plugin install https://github.com/nouney/helm-gcs --version "$GCS_PLUGIN_VERSION"
 fi
 
-helmfile "$@"
+exec helmfile "$@"
 


### PR DESCRIPTION
The build was passing, even though I was accidentally running this step as `helmfile --file <path>` without specifying a sub-command like `apply`.

Checking the logs, the step had passed, but `helmfile` was simply outputting its help text.