### PR TITLE
[helm] Force stable-repo-url for Helm <2.16.x versions

### DIFF
--- a/helm/helm.bash
+++ b/helm/helm.bash
@@ -32,7 +32,7 @@ fi
 
 # if HELM_VERSION starts with v2, initialize Helm
 if [[ $HELM_VERSION =~ ^v2 ]]; then
-  echo "Running: helm init --client-only"
+  echo "Running: helm init --stable-repo-url https://charts.helm.sh/stable --client-only"
   helm init --client-only
 else
   echo "Skipped 'helm init --client-only' because not v2"


### PR DESCRIPTION
If using any Helm version previous to 2.17, the default stable repo url https://kubernetes-charts.storage.googleapis.com/index.yaml is not available any longer, so the `helm init` command fails.
```
Running: helm init --client-only
Creating /builder/home/.helm/repository/repositories.yaml 
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

This commit forces the stable repo url to `https://charts.helm.sh/stable`.