### PR TITLE
yarn-puppeteer: add node 14.15.4, bump chromium and puppeteer 

### DIFF
--- a/yarn-puppeteer/Dockerfile
+++ b/yarn-puppeteer/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION
 FROM node:$NODE_VERSION-alpine
 
-# Installs latest Chromium (79) package.
+# Installs latest Chromium (86) package.
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
@@ -20,10 +20,10 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV JEST_PUPPETEER_CONFIG jest-puppeteer.config.ci.js
 ENV CI true
 
-# Puppeteer v2.0.0 works with Chromium 79.
+# Puppeteer v2.0.0 works with Chromium 86.
 # - This installation of puppeteer will not be used if the web project this cloud builder is used
 #   on installs puppeteer itself. I.e the web project's puppeteer dependency will take precedence.
-RUN yarn add puppeteer@2.0.0
+RUN yarn add puppeteer@5.5.0
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init

--- a/yarn-puppeteer/cloudbuild.yaml
+++ b/yarn-puppeteer/cloudbuild.yaml
@@ -9,8 +9,6 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=12.14.1'
   - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
-  # 12.14.1 is tagged :latest
-  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -18,19 +16,29 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=13.6.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
-  # 13.6.0 is tagged :current
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=14.15.4'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-14.15.4'
+  # 14.15.4 is tagged :current and :latest
   - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:current'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
   - '.'
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
   args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-14.15.4'
+  args: ['--version']
 
 # Test the cloud builder on the example
 - name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['install']
   dir: 'examples/hello_world'
+
 - name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
   args: ['test:puppeteer']
   dir: 'examples/hello_world'
@@ -39,6 +47,13 @@ steps:
   args: ['install']
   dir: 'examples/hello_world'
 - name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
+  args: ['test:puppeteer']
+  dir: 'examples/hello_world'
+
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-14.15.4'
+  args: ['install']
+  dir: 'examples/hello_world'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-14.15.4'
   args: ['test:puppeteer']
   dir: 'examples/hello_world'
 
@@ -47,5 +62,6 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn-puppeteer:current'
 - 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-12.14.1'
 - 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-13.6.0'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-14.15.4'
 - 'gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'
 tags: ['cloud-builders-community']


### PR DESCRIPTION
adds support for node 14.15.4 which is the latest node lts version
also bumps chromium to 86 and puppeteer to 5.5.0

