### PR TITLE
Adding builder for bookdown

### DIFF
--- a/bookdown/Dockerfile
+++ b/bookdown/Dockerfile
@@ -1,0 +1,16 @@
+FROM pandoc/core
+
+ARG BOOKDOWN_VERSION=0.21
+
+RUN apk add --update \
+    R \
+    R-dev \
+    make \
+    musl-dev \
+    g++ && \
+    rm -rf /var/chache/apk/*
+
+RUN Rscript -e "install.packages('bookdown', repos = 'https://cloud.r-project.org', clean = TRUE, INSTALL_opts = c('--no-docs', '--no-help', '--no-demo', '--without-keep.source', '--without-keep.parse.data'))"
+
+ENTRYPOINT ["/usr/bin/Rscript"]
+CMD ["-e", "bookdown::render_book('index.Rmd', 'all')"]

--- a/bookdown/README.md
+++ b/bookdown/README.md
@@ -1,0 +1,13 @@
+# Bookdown
+
+The [bookdown](https://bookdown.org/) package is an open-source R package that
+facilitates writing books and long-form articles/reports with R Markdown.
+
+## Usage:
+
+To generate a book from its sources:
+
+```
+steps:
+- name: gcr.io/$PROJECT_ID/bookdown
+```

--- a/bookdown/cloudbuild.yaml
+++ b/bookdown/cloudbuild.yaml
@@ -1,0 +1,11 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/${PROJECT_ID}/bookdown', '.']
+- name: 'gcr.io/${PROJECT_ID}/bookdown'
+  args: ['--help']
+
+images: ['gcr.io/${PROJECT_ID}/bookdown']
+tags: ['cloud-builders-community']

--- a/bookdown/example/.gitignore
+++ b/bookdown/example/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/bookdown/example/cloudbuild.yaml
+++ b/bookdown/example/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/$PROJECT_ID/bookdown'
+- name: busybox
+  args: ["cat", "_book/index.html"]
+tags: ['cloud-builders-community']

--- a/bookdown/example/index.Rmd
+++ b/bookdown/example/index.Rmd
@@ -1,0 +1,17 @@
+---
+title: "A Book"
+author: "Frida Gomam"
+site: bookdown::bookdown_site
+documentclass: book
+output:
+  bookdown::gitbook: default
+  #bookdown::pdf_book: default
+---
+
+# Hello World
+
+Hi.
+
+Bye.
+
+<!-- If you need PDF output, uncomment bookdown::pdf_book above in YAML. You will need a LaTeX installation, e.g., https://yihui.name/tinytex/ -->


### PR DESCRIPTION
This PR introduces the builder for [Bookdown](https://bookdown.org/). The bookdown package is an open-source R package that facilitates writing books and long-form articles/reports with R Markdown.