### PR TITLE
Use ubuntu base, similar to other docker-based gcp builders

### DIFF
--- a/earthly/Dockerfile
+++ b/earthly/Dockerfile
@@ -1,12 +1,13 @@
-FROM alpine
-
-RUN apk add --no-cache wget
+FROM ubuntu:bionic
 
 ARG VERSION=0.4.4
 ARG PLATFORM=linux
 ARG ARCH=amd64
 
-RUN wget -qO /usr/local/bin/earthly https://github.com/earthly/earthly/releases/download/v$VERSION/earthly-$PLATFORM-$ARCH && \
+RUN apt-get -y update && \
+    apt-get -y install ca-certificates wget docker.io && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -qO /usr/local/bin/earthly https://github.com/earthly/earthly/releases/download/v$VERSION/earthly-$PLATFORM-$ARCH && \
     chmod +x /usr/local/bin/earthly
 
 ENTRYPOINT ["earthly"]


### PR DESCRIPTION
Fixes some issues with the `earthly` GCP builder and a docker-io dependency.