### PR TITLE
upgraded sonarQube and ubuntu instead of alpine

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -1,19 +1,19 @@
-FROM alpine:latest
+FROM ubuntu:latest
 
 LABEL maintainer "Ram Gopinathan"
 
-ARG SONARQUBE_SCANNER_CLI_VERSION="3.2.0.1227"
+ARG SONARQUBE_SCANNER_CLI_VERSION="4.6.0.2311"
 
 ENV SONARQUBE_SCANNER_HOME /opt/sonar-scanner-${SONARQUBE_SCANNER_CLI_VERSION}-linux
 ENV SONARQUBE_SCANNER_BIN ${SONARQUBE_SCANNER_HOME}/bin
 ENV SONAR_SCANNER_CLI_DOWNLOAD_URL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONARQUBE_SCANNER_CLI_VERSION}-linux.zip"
 
-RUN apk update \
-	&& apk upgrade \
-	&& apk add ca-certificates \
+RUN apt-get update \
+	&& apt-get -y upgrade \
+	&& apt-get install -y ca-certificates \
 	&& update-ca-certificates \
-	&& apk add --update openjdk11-jre tzdata curl unzip bash \
-	&& rm -rf /var/cache/apk/* \
+	&& apt-get install -y openjdk-11-jdk-headless tzdata curl unzip bash \
+	&& rm -rf /var/cache/apt/* \
     && mkdir -p /tmp/sonar-scanner  \
 	&& curl -L --silent ${SONAR_SCANNER_CLI_DOWNLOAD_URL} >  /tmp/sonar-scanner/sonar-scanner-cli-${SONARQUBE_SCANNER_CLI_VERSION}-linux.zip  \
     && mkdir -p /opt  \

--- a/sonarqube/cloudbuild.yaml
+++ b/sonarqube/cloudbuild.yaml
@@ -3,15 +3,15 @@ steps:
   args: 
   - 'build'
   - '--build-arg'
-  - 'SONARQUBE_SCANNER_CLI_VERSION=3.2.0.1227'
+  - 'SONARQUBE_SCANNER_CLI_VERSION=4.6.0.2311'
   - '-t'
   - 'gcr.io/$PROJECT_ID/sonar-scanner:latest'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/sonar-scanner:3.2.0.1227'
+  - 'gcr.io/$PROJECT_ID/sonar-scanner:4.6.0.2311'
   - '.'
 
 images: 
 - 'gcr.io/$PROJECT_ID/sonar-scanner:latest'
-- 'gcr.io/$PROJECT_ID/sonar-scanner:3.2.0.1227'
+- 'gcr.io/$PROJECT_ID/sonar-scanner:4.6.0.2311'
 
 tags: ['cloud-builders-community']


### PR DESCRIPTION
- Upgraded SonarQube to the latest version (v4.6.0.2311)
- Replaced the base image from alpine to Ubuntu. Alpine can [cause problems with java]( https://community.sonarsource.com/t/sonar-scanner-error-exec-line-59-jre-bin-java-not-found/11255)