### PR TITLE
Add cypress dependencies

### DIFF
--- a/cypress-dependencies/Dockerfile
+++ b/cypress-dependencies/Dockerfile
@@ -1,6 +1,3 @@
-ARG NODE_VERSION=latest
-FROM node:${NODE_VERSION}
-
-RUN apt update && apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+FROM cypress/browsers:chrome67
 
 ENTRYPOINT ["yarn"]

--- a/cypress-dependencies/Dockerfile
+++ b/cypress-dependencies/Dockerfile
@@ -1,0 +1,6 @@
+ARG NODE_VERSION=latest
+FROM node:${NODE_VERSION}
+
+RUN apt update && apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+ENTRYPOINT ["yarn"]

--- a/cypress-dependencies/README.md
+++ b/cypress-dependencies/README.md
@@ -1,0 +1,15 @@
+# Cypress dependencies
+
+This allows you to run cypress in GCB.
+
+You need to have `cypress` in you `package.json` and run `yarn install` before running cypress.
+
+## Example build
+
+```yaml
+steps:
+- name: 'gcr.io/cloud-builders/yarn'
+  args: ['install']
+- name: 'gcr.io/$PROJECT_ID/cypress-dependencies'
+  args: ['cypress', 'run', '--headless']
+```

--- a/cypress-dependencies/README.md
+++ b/cypress-dependencies/README.md
@@ -13,3 +13,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/cypress-dependencies'
   args: ['cypress', 'run', '--headless']
 ```
+
+## Useful links
+- Cypress documentation: https://docs.cypress.io
+- Cypress inside docker: https://docs.cypress.io/examples/examples/docker.html
+- Base image: https://hub.docker.com/r/cypress/browsers

--- a/cypress-dependencies/cloudbuild.yaml
+++ b/cypress-dependencies/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/cypress-dependencies', '.']
+
+images: ['gcr.io/$PROJECT_ID/cypress-dependencies:latest']
+tags: ['cloud-builders-community']

--- a/cypress-dependencies/examples/cloudbuild.yaml
+++ b/cypress-dependencies/examples/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/yarn'
+  args: ['install']
+- name: 'gcr.io/$PROJECT_ID/cypress-dependencies'
+  args: ['cypress', 'run', '--headless']


### PR DESCRIPTION
# Cypress dependencies

This allows you to run cypress in GCB.

You need to have `cypress` in you `package.json` and run `yarn install` before running cypress.

## Example build

```yaml
steps:
- name: 'gcr.io/cloud-builders/yarn'
  args: ['install']
- name: 'gcr.io/$PROJECT_ID/cypress-dependencies'
  args: ['cypress', 'run', '--headless']
```