### PR TITLE
docker entry point and registry name fix

### DIFF
--- a/dataflow-python3/Dockerfile
+++ b/dataflow-python3/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.7
 
 RUN virtualenv venv
 
+ENTRYPOINT bin/bash
+
 RUN /bin/bash -c "source venv/bin/activate"
 
 RUN pip install apache-beam[gcp]

--- a/dataflow-python3/examples/DataflowRunner/cloudbuild.yaml
+++ b/dataflow-python3/examples/DataflowRunner/cloudbuild.yaml
@@ -1,9 +1,9 @@
 steps:
-- name: 'gcr.io/$PROJECT_ID/dataflow-python'
+- name: 'gcr.io/$PROJECT_ID/dataflow-python3'
   entrypoint: '/bin/bash'
   args: [ '-c',
           'source /venv/bin/activate' ]
-- name: 'gcr.io/$PROJECT_ID/dataflow-python'
+- name: 'gcr.io/$PROJECT_ID/dataflow-python3'
   entrypoint: 'python'
   args: [ '-m',
           'apache_beam.examples.wordcount',


### PR DESCRIPTION
1. Fix the issue where path /bin/bash is not recognized because entrypoint is not set
2. Fix cloud builder name which was set differently from original image name