### PR TITLE
Fix ko builds

### DIFF
--- a/ko/Dockerfile
+++ b/ko/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.15
+FROM golang:1.16 AS kosource
+ARG KO_GIT_TAG
 
-ENV GO111MODULE=on
-RUN CGO_ENABLED=0 GOOS=linux go get github.com/google/ko/cmd/ko
+RUN git clone --depth=1 -b "${KO_GIT_TAG}" https://github.com/google/ko
+WORKDIR ko
+RUN GOOS=linux go build -mod=vendor -o /bin/ko ./cmd/ko
 
 FROM gcr.io/cloud-builders/kubectl
 
-COPY --from=0 /go/bin/ko /
+COPY --from=kosource /bin/ko /
 COPY ko.bash /builder/ko.bash
 
 # Install Go

--- a/ko/README.md
+++ b/ko/README.md
@@ -7,12 +7,19 @@ Build.
 This Cloud Builder inherits from [gcr.io/cloud-builders/kubectl][kubectl] and
 therefore requires a similar [setup][setup].
 
-## Building this buildero
+## Building this builder
 
 To build this builder, run the following command in this directory.
 
 ```
 $ gcloud builds submit . --config=cloudbuild.yaml
+```
+
+To build a specific version of `ko`, add a substitution setting `_KO_GIT_TAG` to be
+the branch or tag you want to build:
+
+```
+$ gcloud builds submit . --config=cloudbuild.yaml --substitutions=_KO_GIT_TAG="v0.8.1"
 ```
 
 [ko]: https://github.com/google/ko

--- a/ko/cloudbuild.yaml
+++ b/ko/cloudbuild.yaml
@@ -1,6 +1,8 @@
+substitutions:
+    _KO_GIT_TAG: 'main'
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/ko', '.']
+  args: ['build', '--build-arg', 'KO_GIT_TAG=${_KO_GIT_TAG}', '--tag=gcr.io/$PROJECT_ID/ko', '.']
 - name: 'gcr.io/$PROJECT_ID/ko'
   args: ['version']
 


### PR DESCRIPTION
ko requires golang 1.16 https://github.com/google/ko#build-and-install-from-source and the vendor directory to be used for correct dependency resolution which means the git repo has to be pulled in order to correctly build it without running into arbitrary breaking changes due to upstream libraries.

This PR also adds the ability to build a specific version of ko so users can choose to pin the version they use.