### PR TITLE
Moving cleanup trap before the retry loop

### DIFF
--- a/remote-builder/run-builder.sh
+++ b/remote-builder/run-builder.sh
@@ -38,6 +38,8 @@ ${GCLOUD} compute instances create \
        --metadata block-project-ssh-keys=TRUE \
        --metadata-from-file ssh-keys=ssh-keys
 
+trap cleanup EXIT
+
 RETRY_COUNT=1
 while [ "$(ssh 'printf pass')" != "pass" ]; do
   echo "[Try $RETRY_COUNT of $RETRIES] Waiting for instance to start accepting SSH connections..."
@@ -48,8 +50,6 @@ while [ "$(ssh 'printf pass')" != "pass" ]; do
   sleep 10
   RETRY_COUNT=$(($RETRY_COUNT+1))
 done
-
-trap cleanup EXIT
 
 ${GCLOUD} compute scp --compress --recurse \
        $(pwd) ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \


### PR DESCRIPTION
In a previous pull request a retry loop was introduced, causing the script to exit when the number of retry to check the ssh connexion is exceeded. This loop was placed before the ```trap cleanup EXIT``` causing the created instance to not be cleaned up when the loop causes the exit.

This PR moves ```trap cleanup EXIT``` before the loop to ensure the instance is cleaned.