### PR TITLE
Adding a parameter to allow custom args for ssh and scp commands

### DIFF
--- a/remote-builder/README.md
+++ b/remote-builder/README.md
@@ -73,7 +73,9 @@ build step in the `env` parameter:
 | REMOTE_WORKSPACE  | Location on remote host to use as workspace | `/home/${USERNAME}/workspace/` |
 | INSTANCE_NAME  | Name of the instance that is launched  | `builder-$UUID` |
 | ZONE  | Compute zone to launch the instance in | `us-central1-f` |
-| INSTANCE_ARGS| Parameters to the instance creation command. For a full list run `gcloud compute instances create --help`| `--preemptible` |
+| INSTANCE_ARGS| Parameters to the instance creation command. For a full list run `gcloud compute instances create --help` | `--preemptible` |
+| SSH_ARGS| Parameters to the ssh and scp commands. This can be useful to run ssh though a IAP tunnel with ```--tunnel-though-iap``` | `` |
+| RETRIES| The number of retries to wait for the instance to start accepting SSH connections | `10` |
 
 To give it a try, see the [examples directory](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/remote-builder/examples).
 

--- a/remote-builder/README.md
+++ b/remote-builder/README.md
@@ -74,7 +74,7 @@ build step in the `env` parameter:
 | INSTANCE_NAME  | Name of the instance that is launched  | `builder-$UUID` |
 | ZONE  | Compute zone to launch the instance in | `us-central1-f` |
 | INSTANCE_ARGS| Parameters to the instance creation command. For a full list run `gcloud compute instances create --help` | `--preemptible` |
-| SSH_ARGS| Parameters to the ssh and scp commands. This can be useful to run ssh though a IAP tunnel with ```--tunnel-though-iap``` | `` |
+| SSH_ARGS| Parameters to the ssh and scp commands. This can be useful to run ssh though a IAP tunnel with ```--tunnel-though-iap``` | None |
 | RETRIES| The number of retries to wait for the instance to start accepting SSH connections | `10` |
 
 To give it a try, see the [examples directory](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/remote-builder/examples).

--- a/remote-builder/run-builder.sh
+++ b/remote-builder/run-builder.sh
@@ -1,16 +1,5 @@
 #!/bin/bash -xe
 
-# Always delete instance after attempting build
-function cleanup {
-    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --quiet
-}
-
-# Run command on the instance via ssh
-function ssh {
-    ${GCLOUD} compute ssh --ssh-key-file=${KEYNAME} \
-         ${USERNAME}@${INSTANCE_NAME} -- $1
-}
-
 # Configurable parameters
 [ -z "$COMMAND" ] && echo "Need to set COMMAND" && exit 1;
 
@@ -19,8 +8,20 @@ REMOTE_WORKSPACE=${REMOTE_WORKSPACE:-/home/${USERNAME}/workspace/}
 INSTANCE_NAME=${INSTANCE_NAME:-builder-$(cat /proc/sys/kernel/random/uuid)}
 ZONE=${ZONE:-us-central1-f}
 INSTANCE_ARGS=${INSTANCE_ARGS:---preemptible}
+SSH_ARGS=${SSH_ARGS:-}
 GCLOUD=${GCLOUD:-gcloud}
-RETRIES=10
+RETRIES=${RETRIES:-10}
+
+# Always delete instance after attempting build
+function cleanup {
+    ${GCLOUD} compute instances delete ${INSTANCE_NAME} --quiet
+}
+
+# Run command on the instance via ssh
+function ssh {
+    ${GCLOUD} compute ssh ${SSH_ARGS} --ssh-key-file=${KEYNAME} \
+         ${USERNAME}@${INSTANCE_NAME} -- $1
+}
 
 ${GCLOUD} config set compute/zone ${ZONE}
 
@@ -51,12 +52,12 @@ while [ "$(ssh 'printf pass')" != "pass" ]; do
   RETRY_COUNT=$(($RETRY_COUNT+1))
 done
 
-${GCLOUD} compute scp --compress --recurse \
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
        $(pwd) ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE} \
        --ssh-key-file=${KEYNAME}
 
 ssh "${COMMAND}"
 
-${GCLOUD} compute scp --compress --recurse \
+${GCLOUD} compute scp ${SSH_ARGS} --compress --recurse \
        ${USERNAME}@${INSTANCE_NAME}:${REMOTE_WORKSPACE}* $(pwd) \
        --ssh-key-file=${KEYNAME}


### PR DESCRIPTION
* Parametrizing the number of retries ```RETRIES=${RETRIES:-10}```
* Adding ```SSH_ARGS=${SSH_ARGS:-}``` to allow users of the image to add args to ```${GCLOUD} compute ssh``` and ```${GCLOUD} compute scp```. This is particularly useful to allow the use of IAP tunnels with ```--tunnel-through-iap``` when direct SSH connections from external subnetwork (like from a worker on cloud-builder) are forbidden at an organisation level.

The default values of the two new parameters ensure backward compatibility with the previous version of the image.