### PR TITLE
[jsonnet] install jsonnet after building

### DIFF
--- a/jsonnet/Dockerfile
+++ b/jsonnet/Dockerfile
@@ -6,6 +6,7 @@ RUN \
     git clone https://github.com/google/jsonnet.git && \
     cd jsonnet && \
     make && \
+    make install && \
     ./jsonnet --help
 
 ENTRYPOINT ["/jsonnet/jsonnet"]


### PR DESCRIPTION
I often like to use Makefiles to help generate my `jsonnet` configuration, and I'm trying to make this Cloud Builder work with that kind of setup.

If `jsonnet` gets installed into `$PATH` after we build it, then I can set my entrypoint to `bash` or `make` and invoke `jsonnet` indirectly. That lets me do what I want without making any destructive changes.