### PR TITLE
Multiple windows-builder improvements

### DIFF
--- a/windows-builder/builder/Dockerfile
+++ b/windows-builder/builder/Dockerfile
@@ -3,8 +3,8 @@ FROM golang AS build-env
 ADD ./ /go/src/builder
 WORKDIR /go/src/builder
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -o /go/bin/main
+RUN GO111MODULE=on CGO_ENABLED=0 go build -o /go/bin/main && strip /go/bin/main
 
 FROM gcr.io/distroless/base-debian10
-COPY --from=build-env /go/bin/main /bin/main
-ENTRYPOINT [ "/bin/main" ]
+COPY --from=build-env /go/bin/main /usr/local/bin/main
+ENTRYPOINT [ "/usr/local/bin/main" ]

--- a/windows-builder/builder/builder/gce.go
+++ b/windows-builder/builder/builder/gce.go
@@ -143,6 +143,11 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 		machineType = "n1-standard-1"
 	}
 
+	diskType := *bs.DiskType
+	if diskType == "" {
+		diskType = "pd-standard"
+	}
+
 	instance := &compute.Instance{
 		Name:        name,
 		MachineType: prefix + s.projectID + "/zones/" + *bs.Zone + "/machineTypes/" + machineType,
@@ -154,6 +159,8 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					DiskName:    fmt.Sprintf("%s-pd", name),
 					SourceImage: prefix + *bs.ImageUrl,
+					DiskSizeGb:  *bs.DiskSizeGb,
+					DiskType:    prefix + s.projectID + "/zones/" + *bs.Zone + "/diskTypes/" + diskType,
 				},
 			},
 		},

--- a/windows-builder/builder/builder/gce.go
+++ b/windows-builder/builder/builder/gce.go
@@ -193,6 +193,9 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 			},
 		},
 		Labels: bs.GetLabelsMap(),
+		Scheduling: &compute.Scheduling{
+			Preemptible: *bs.Preemptible,
+		},
 	}
 
 	op, err := s.service.Instances.Insert(s.projectID, *bs.Zone, instance).Do()

--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -36,6 +36,7 @@ type BuilderServer struct {
 	Zone           *string
 	Labels         *string
 	MachineType    *string
+	Preemptible    *bool
 	DiskSizeGb     *int64
 	DiskType       *string
 	ServiceAccount *string

--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -36,6 +36,8 @@ type BuilderServer struct {
 	Zone           *string
 	Labels         *string
 	MachineType    *string
+	DiskSizeGb     *int64
+	DiskType       *string
 	ServiceAccount *string
 }
 

--- a/windows-builder/builder/cloudbuild.yaml
+++ b/windows-builder/builder/cloudbuild.yaml
@@ -1,6 +1,9 @@
+substitutions:
+  _BUILDER: "windows-builder"
+  _REGISTRY: "gcr.io"
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/windows-builder', '.' ]
+  args: [ 'build', '-t', '${_REGISTRY}/$PROJECT_ID/${_BUILDER}', '.' ]
 images:
-- 'gcr.io/$PROJECT_ID/windows-builder'
+- '${_REGISTRY}/$PROJECT_ID/${_BUILDER}'
 tags: ['cloud-builders-community']

--- a/windows-builder/builder/go.sum
+++ b/windows-builder/builder/go.sum
@@ -166,6 +166,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os/signal"
 	"context"
+	"syscall"
 	"flag"
 	"log"
 	"os"
@@ -24,6 +26,8 @@ var (
 	zone             = flag.String("zone", "us-central1-f", "The zone name to use when creating the Windows server")
 	labels           = flag.String("labels", "", "List of label KEY=VALUE pairs separated by comma to add when creating the Windows server")
 	machineType      = flag.String("machineType", "", "The machine type to use when creating the Windows server")
+	diskSizeGb       = flag.Int64("diskSizeGb", 50, "The disk size to use when creating the Windows server")
+	diskType         = flag.String("diskType", "", "The disk type to use when creating the Windows server")
 	commandTimeout   = flag.Int("commandTimeout", 5, "The command run timeout in minutes")
 	copyTimeout      = flag.Int("copyTimeout", 5, "The workspace copy timeout in minutes")
 	serviceAccount   = flag.String("serviceAccount", "default", "The service account to use when creating the Windows server")
@@ -54,11 +58,23 @@ func main() {
 			Zone:           zone,
 			Labels:         labels,
 			MachineType:    machineType,
+			DiskSizeGb:     diskSizeGb,
+			DiskType:       diskType,
 			ServiceAccount: serviceAccount,
 		}
 		s = builder.NewServer(ctx, bs)
 		r = &s.Remote
+
+		log.Print("Setting up termination signal handler")
+		sigsChannel := make(chan os.Signal, 1)
+		signal.Notify(sigsChannel, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+		go func() {
+			sig := <-sigsChannel
+			log.Printf("Signal %+v received, terminating", sig)
+			deleteInstanceAndExit(s, bs, 1)
+		}()
 	}
+
 	log.Print("Waiting for server to become available")
 	err := r.Wait()
 	if err != nil {

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -26,6 +26,7 @@ var (
 	zone             = flag.String("zone", "us-central1-f", "The zone name to use when creating the Windows server")
 	labels           = flag.String("labels", "", "List of label KEY=VALUE pairs separated by comma to add when creating the Windows server")
 	machineType      = flag.String("machineType", "", "The machine type to use when creating the Windows server")
+	preemptible      = flag.Bool("preemptible", false, "If instance running the Windows server should be preemptible or not")
 	diskSizeGb       = flag.Int64("diskSizeGb", 50, "The disk size to use when creating the Windows server")
 	diskType         = flag.String("diskType", "", "The disk type to use when creating the Windows server")
 	commandTimeout   = flag.Int("commandTimeout", 5, "The command run timeout in minutes")
@@ -58,6 +59,7 @@ func main() {
 			Zone:           zone,
 			Labels:         labels,
 			MachineType:    machineType,
+			Preemptible:	preemptible,
 			DiskSizeGb:     diskSizeGb,
 			DiskType:       diskType,
 			ServiceAccount: serviceAccount,


### PR DESCRIPTION
* Added support for specifying `diskSize` and `diskType`
* Implemented termination signal handler
* Main binary stripped and moved to `/usr/local/bin` instead of `/bin`
* Added missing hash for `golang.org/x/sys` into `go.sum`
* Added support for windows-builder to run as a preemptible instance
* Added substitutions into window-builder cloudbuild YAML definition