### PR TITLE
explicit use of node 14

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:14
 
 RUN npm i -g firebase-tools
 ADD firebase.bash /usr/bin


### PR DESCRIPTION
The base node image is using node 15 which is not LTS and not supported by cloud functions.