### PR TITLE
envsubst - Fix when more than 2 arguments

### DIFF
--- a/envsubst/entrypoint.bash
+++ b/envsubst/entrypoint.bash
@@ -32,7 +32,7 @@ while true; do
             ;;
         *)
             files[files_count]="${1}"
-            files_count=$((  + 1 ))
+            files_count=$(( files_count + 1 ))
             shift
             ;;
     esac


### PR DESCRIPTION
The previous code:

```sh
 files_count=$((  + 1 ))
```

Is effectively the same as:

```sh
files_count=1
```

I suspect the double space meant originaly it was:

```sh
files_count=$(( files_count + 1 ))
```

Somehow an editing error occurred and the `files_count` was removed. The result is the first argument is indexed at 0 (from above) all subsequent values are indexed at 1 with each later argument overwriting the previous. This means only the first and last argument are actually processed.

This fixes the code so that all arguments are processed.