### PR TITLE
Bump Hugo version

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.83.1
+ENV HUGO_VERSION=0.88.1
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/cc


### PR DESCRIPTION
This PR updates the Hugo version to [0.88.1](https://gohugo.io/news/0.88.1-relnotes/)