### PR TITLE
[firebase]: Add Python and JRE dependencies

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,6 +1,15 @@
-FROM node
+FROM node:lts-alpine3.14 AS app-env
 
-RUN npm i -g firebase-tools
+# Install Python and Java and pre-cache emulator dependencies.
+RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
+    npm install -g firebase-tools && \
+    firebase setup:emulators:database && \
+    firebase setup:emulators:firestore && \
+    firebase setup:emulators:pubsub && \
+    firebase setup:emulators:storage && \
+    firebase setup:emulators:ui && \
+    rm -rf /var/cache/apk/* \
+
 ADD firebase.bash /usr/bin
 RUN chmod +x /usr/bin/firebase.bash
 

--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
     firebase setup:emulators:pubsub && \
     firebase setup:emulators:storage && \
     firebase setup:emulators:ui && \
-    rm -rf /var/cache/apk/* \
+    rm -rf /var/cache/apk/*
 
 ADD firebase.bash /usr/bin
 RUN chmod +x /usr/bin/firebase.bash


### PR DESCRIPTION
This PR fixes #441. Also closes #398.

The builder is now based on `node:lts-alpine3.14` image and has required Python and JDK dependencies. Also, all Firebase emulators are pre-cached in order to improve the runtime experience.