### PR TITLE
Make --tags optional in windows-builder.

### DIFF
--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -223,6 +223,10 @@ func (bs *BuilderServer) GetLabelsMap() map[string]string {
 }
 
 func (bs *BuilderServer) GetTags() []string {
+  if *bs.Tags == "" {
+    return nil
+  }
+
 	var tags []string
   for _, tag := range strings.Split(*bs.Tags, ",") {
 		tags = append(tags, strings.TrimSpace(tag))


### PR DESCRIPTION
Do not use empty tags when creating GCE instance. This PR fixes issue #[537](https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/537).