### PR TITLE
Add an option to use an internal ip address.

### DIFF
--- a/windows-builder/README.md
+++ b/windows-builder/README.md
@@ -115,6 +115,15 @@ For ephemeral VMs on Compute Engine, the initial password reset is performed [us
 
 The latest version of Windows Server 2019 DC Core for Containers (patched 2019-12-10) is currently used.
 
+By default, windows-builder creates an ingress firewall rule to open tcp:5986.  This allows windows-builder to communicate
+with windows GCE instance over WinRM.  It's possible to avoid an external access by using a [private worker pool](https://cloud.google.com/build/docs/private-pools/private-pools-overview) and peering
+it with your private VPC network.  With such set up windows-builder can communicate with GCE instance(s) over an internal network.  To do that you will need to [set up](https://cloud.google.com/build/docs/private-pools/set-up-private-pool-environment) your GCP network, create a [private worker pool](https://cloud.google.com/build/docs/private-pools/create-manage-private-pools), configure [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access), [configure](https://cloud.google.com/build/docs/private-pools/run-builds-in-private-pool) your builder to use a private worker pool, and use --use-internal-network windows-builder option in your cloudbuild.yaml.
+
+Using internal network option precludes windows-builder from creating an external ip address for windows GCE instance.
+You can use --create-external-ip (can only be used in conjunction with --use-internal-network) which would override the
+default behavior and create an external IP address.  This can be useful in case you want to be able to RDP to your
+GCE instance(s).
+
 ## Docker builds
 
 Windows supports [two different types](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container) of containers: "Windows Server containers", similar to the traditional Linux container, and "Hyper-V containers", which rely on Virtual Machines.  This code uses Windows Server containers, and as a result both the major and minor version of Windows must match between container and host.

--- a/windows-builder/builder/builder/gce.go
+++ b/windows-builder/builder/builder/gce.go
@@ -93,18 +93,29 @@ func NewServer(ctx context.Context, bs *BuilderServer) *Server {
 		log.Fatalf("Failed to reset Windows password: %+v", err)
 	}
 
-	// Set firewall rule.
-	err = s.setFirewallRule(bs)
-	if err != nil {
-		log.Fatalf("Failed to set ingress firewall rule: %v", err)
-	}
-	log.Printf("Set ingress firewall rule successfully")
+	var ip string
 
-	// Get IP address.
-	ip, err := s.getExternalIP(bs)
-	if err != nil {
-		log.Fatalf("Failed to get external IP address: %v", err)
-		return nil
+	if *bs.UseInternalNet {
+		// Get internal IP address.
+		ip, err = s.getInternalIP(bs)
+		if err != nil {
+			log.Fatalf("Failed to get internal IP address: %v", err)
+			return nil
+		}
+	} else {
+		// Set firewall rule.
+		err = s.setFirewallRule(bs)
+		if err != nil {
+			log.Fatalf("Failed to set ingress firewall rule: %v", err)
+		}
+		log.Printf("Set ingress firewall rule successfully")
+
+		// Get IP address.
+		ip, err = s.getExternalIP(bs)
+		if err != nil {
+			log.Fatalf("Failed to get external IP address: %v", err)
+			return nil
+		}
 	}
 
 	// Set and return Remote.
@@ -148,6 +159,16 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 		diskType = "pd-standard"
 	}
 
+	accessConfigs := []*compute.AccessConfig{}
+	if *bs.CreateExternalIP {
+		accessConfigs = []*compute.AccessConfig{
+			&compute.AccessConfig{
+				Type: "ONE_TO_ONE_NAT",
+				Name: "External NAT",
+			},
+		}
+	}
+
 	instance := &compute.Instance{
 		Name:        name,
 		MachineType: prefix + s.projectID + "/zones/" + *bs.Zone + "/machineTypes/" + machineType,
@@ -174,12 +195,7 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 		},
 		NetworkInterfaces: []*compute.NetworkInterface{
 			&compute.NetworkInterface{
-				AccessConfigs: []*compute.AccessConfig{
-					&compute.AccessConfig{
-						Type: "ONE_TO_ONE_NAT",
-						Name: "External NAT",
-					},
-				},
+				AccessConfigs: accessConfigs,
 				Network:    prefix + s.projectID + "/global/networks/" + *bs.VPC,
 				Subnetwork: prefix + s.projectID + "/regions/" + *bs.Region + "/subnetworks/" + *bs.Subnet,
 			},
@@ -242,6 +258,19 @@ func (s *Server) DeleteInstance(bs *BuilderServer) error {
 		return err
 	}
 	return nil
+}
+
+// getInternalIP gets an internal IP for an instance.
+func(s *Server) getInternalIP(bs *BuilderServer) (string, error) {
+	err := s.refreshInstance(bs)
+	if err != nil {
+		log.Printf("Error refreshing instance: %+v", err)
+	}
+	internalIP := s.instance.NetworkInterfaces[0].NetworkIP
+	if internalIP == "" {
+		return "", errors.New("Could not get internal IP from list")
+	}
+	return internalIP, nil
 }
 
 // getExternalIP gets the external IP for an instance.

--- a/windows-builder/builder/builder/remote.go
+++ b/windows-builder/builder/builder/remote.go
@@ -29,18 +29,20 @@ type Remote struct {
 }
 
 type BuilderServer struct {
-	ImageUrl       *string
-	VPC            *string
-	Subnet         *string
-	Region         *string
-	Zone           *string
-	Labels         *string
-	MachineType    *string
-	Preemptible    *bool
-	DiskSizeGb     *int64
-	DiskType       *string
-	ServiceAccount *string
-	Tags           *string
+	ImageUrl          *string
+	VPC               *string
+	Subnet            *string
+	Region            *string
+	Zone              *string
+	Labels            *string
+	MachineType       *string
+	Preemptible       *bool
+	DiskSizeGb        *int64
+	DiskType          *string
+	ServiceAccount    *string
+	Tags              *string
+	UseInternalNet    *bool
+	CreateExternalIP  *bool
 }
 
 // Wait for server to be available.

--- a/windows-builder/builder/main.go
+++ b/windows-builder/builder/main.go
@@ -33,6 +33,8 @@ var (
 	copyTimeout      = flag.Int("copyTimeout", 5, "The workspace copy timeout in minutes")
 	serviceAccount   = flag.String("serviceAccount", "default", "The service account to use when creating the Windows server")
 	tags             = flag.String("tags", "", "List of strings eparated by comma to add when creating the Windows server")
+	useInternalNet   = flag.Bool("use-internal-network", false, "Communicate with Windows server over the internal network")
+	createExternalIP = flag.Bool("create-external-ip", false, "Create an external IP address when using internal network")
 )
 
 func main() {
@@ -53,18 +55,20 @@ func main() {
 	} else {
 		ctx := context.Background()
 		bs = &builder.BuilderServer{
-			ImageUrl:       image,
-			VPC:            network,
-			Subnet:         subnetwork,
-			Region:         region,
-			Zone:           zone,
-			Labels:         labels,
-			MachineType:    machineType,
-			Preemptible:	preemptible,
-			DiskSizeGb:     diskSizeGb,
-			DiskType:       diskType,
-			ServiceAccount: serviceAccount,
-			Tags: 					tags,
+			ImageUrl:         image,
+			VPC:              network,
+			Subnet:           subnetwork,
+			Region:           region,
+			Zone:             zone,
+			Labels:           labels,
+			MachineType:      machineType,
+			Preemptible:      preemptible,
+			DiskSizeGb:       diskSizeGb,
+			DiskType:         diskType,
+			ServiceAccount:   serviceAccount,
+			Tags:             tags,
+			UseInternalNet:   useInternalNet,
+			CreateExternalIP: createExternalIP,
 		}
 		s = builder.NewServer(ctx, bs)
 		r = &s.Remote


### PR DESCRIPTION
This PR addresses issue #545 by adding an option to have windows-builder communicate with GCE instance(s) over internal network.  This functionality can only work with a private worker pool peered with a private VPC network. Compared to the default behavior this should be a more secure option and avoids having users open an external access to their network via a firewall rule.

This PR has been tested with a test job that ran in a private worker pool over internal network.  It was also tested for regression by running a test job with default behavior.