### PR TITLE
Update CLI version to the newest 2.2.0

### DIFF
--- a/github/Dockerfile
+++ b/github/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-ENV CLI_VERSION=1.4.0
+ENV CLI_VERSION=2.2.0
 RUN wget -O- https://github.com/cli/cli/releases/download/v${CLI_VERSION}/gh_${CLI_VERSION}_linux_amd64.tar.gz | tar zx --strip-components=1
 
 ADD gh.bash /usr/bin


### PR DESCRIPTION
Successfully build the image with the new version. Proof:
```
Step 3/7 : ENV CLI_VERSION=2.2.0
 ---> Running in 078cc832cda6
Removing intermediate container 078cc832cda6
 ---> 4f354270bf8e
Step 4/7 : RUN wget -O- https://github.com/cli/cli/releases/download/v${CLI_VERSION}/gh_${CLI_VERSION}_linux_amd64.tar.gz | tar zx --strip-components=1
 ---> Running in 29b0ec64f804
--2021-11-29 23:23:52--  https://github.com/cli/cli/releases/download/v2.2.0/gh_2.2.0_linux_amd64.tar.gz
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/212613049/3a9c0fc3-0cef-48ae-a311-6f4a56f1a761?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20211129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211129T232353Z&X-Amz-Expires=300&X-Amz-Signature=e33172f538d7d5ab6c5924260aa92407fbab56243d6d73867f5f0c0151082b00&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=212613049&response-content-disposition=attachment%3B%20filename%3Dgh_2.2.0_linux_amd64.tar.gz&response-content-type=application%2Foctet-stream [following]
--2021-11-29 23:23:53--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/212613049/3a9c0fc3-0cef-48ae-a311-6f4a56f1a761?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20211129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211129T232353Z&X-Amz-Expires=300&X-Amz-Signature=e33172f538d7d5ab6c5924260aa92407fbab56243d6d73867f5f0c0151082b00&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=212613049&response-content-disposition=attachment%3B%20filename%3Dgh_2.2.0_linux_amd64.tar.gz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7247432 (6.9M) [application/octet-stream]
Saving to: 'STDOUT'

     0K .......... .......... .......... .......... ..........  0% 11.4M 1s
    50K .......... .......... .......... .......... ..........  1% 25.6M 0s
   100K .......... .......... .......... .......... ..........  2% 18.9M 0s
   150K .......... .......... .......... .......... ..........  2% 7.07M 1s
   200K .......... .......... .......... .......... ..........  3% 37.2M 0s
   250K .......... .......... .......... .......... ..........  4% 18.5M 0s
   300K .......... .......... .......... .......... ..........  4% 9.60M 0s
   350K .......... .......... .......... .......... ..........  5% 63.2M 0s
   400K .......... .......... .......... .......... ..........  6% 15.0M 0s
   450K .......... .......... .......... .......... ..........  7% 33.1M 0s
   500K .......... .......... .......... .......... ..........  7% 40.1M 0s
   550K .......... .......... .......... .......... ..........  8% 18.1M 0s
   600K .......... .......... .......... .......... ..........  9% 18.5M 0s
   650K .......... .......... .......... .......... ..........  9% 27.4M 0s
   700K .......... .......... .......... .......... .......... 10% 13.5M 0s
   750K .......... .......... .......... .......... .......... 11% 15.2M 0s
```