### PR TITLE
Update Hugo version to 0.89.4

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV HUGO_VERSION=0.88.1
+ENV HUGO_VERSION=0.89.4
 RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar zx
 
 FROM gcr.io/distroless/cc


### PR DESCRIPTION
This PR updates the [Hugo](https://gohugo.io/) version to [0.89.4](https://github.com/gohugoio/hugo/releases/tag/v0.89.4)