### PR TITLE
Support Android Gradle plugin 7.0.0+

### DIFF
--- a/android/Dockerfile-base
+++ b/android/Dockerfile-base
@@ -1,5 +1,4 @@
-# we use a gcr.io image and not openjdk:8-jdk-slim because it loads faster in the google Google Cloud Build environment
-FROM gcr.io/cloud-builders/javac
+FROM openjdk:11
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -20,7 +19,7 @@ RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
-ARG sdk_version=sdk-tools-linux-4333796.zip
+ARG sdk_version=commandlinetools-linux-7583922_latest.zip
 ARG android_home=/opt/android/sdk
 ARG ndk_version=android-ndk-r17b
 ARG android_ndk_home=/opt/android/${ndk_version}
@@ -28,13 +27,15 @@ ARG android_ndk_home=/opt/android/${ndk_version}
 # Install Android SDK
 RUN sudo mkdir -p ${android_home} && \
     curl --silent --show-error --location --fail --retry 3 --output /tmp/${sdk_version} https://dl.google.com/android/repository/${sdk_version} && \
-    unzip -q /tmp/${sdk_version} -d ${android_home} && \
+    unzip -q /tmp/${sdk_version} -d ${android_home}/cmdline-tools && \
     rm /tmp/${sdk_version}
 
 # Set environment variables
 ENV ANDROID_HOME ${android_home}
 ENV ADB_INSTALL_TIMEOUT 120
-ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}
+
+RUN mv ${android_home}/cmdline-tools/cmdline-tools ${android_home}/cmdline-tools/latest 
 
 RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
 
@@ -47,7 +48,7 @@ RUN yes | sdkmanager \
     "extras;android;m2repository" \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
-    "build-tools;28.0.3"
+    "build-tools;30.0.2"
 
 COPY for_branch /bin
 COPY run_build /bin


### PR DESCRIPTION
The current android cloud builder doesn't support the Android Gradle plugin 7.0.0+ because it use google javac builder which is based on Java 8. The new plugin require Java 11. Maybe we could use openjdk:11-slim or openjdk:11-slim-buster for a lighter image.

The following commit make it work with gradle 7.0.0+.