### PR TITLE
Create external address explicitly if local network is not used.

### DIFF
--- a/windows-builder/builder/builder/gce.go
+++ b/windows-builder/builder/builder/gce.go
@@ -160,7 +160,7 @@ func (s *Server) newInstance(bs *BuilderServer) error {
 	}
 
 	accessConfigs := []*compute.AccessConfig{}
-	if *bs.CreateExternalIP {
+	if !*bs.UseInternalNet || *bs.CreateExternalIP {
 		accessConfigs = []*compute.AccessConfig{
 			&compute.AccessConfig{
 				Type: "ONE_TO_ONE_NAT",


### PR DESCRIPTION
Explicitly create an external ip address if local network option is not used.  This addresses a regression introduced via PR #546 which was discovered in issue #556.