### PR TITLE
Slim down gcloud

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim 
 
 ARG HELM_VERSION=v3.7.0
 ENV HELM_VERSION=$HELM_VERSION


### PR DESCRIPTION
This will make the helm image pull much faster due to the significant decrease in size by using the official gcloud-sdk `gcr.io/google.com/cloudsdktool/cloud-sdk:slim` instead of `gcr.io/cloud-builders/gcloud`

A decrease of 2.44GB making deployments significantly faster

Comparison:

```
REPOSITORY                                 TAG       IMAGE ID       CREATED       SIZE
gcr.io/google.com/cloudsdktool/cloud-sdk   slim      17bebdd116a6   6 hours ago   1.38GB
```

vs

```
REPOSITORY                     TAG       IMAGE ID       CREATED       SIZE
gcr.io/cloud-builders/gcloud   latest    a91749b33916   11 days ago   3.82GB
```
