### PR TITLE
Fix `binauthz-attestation` scripts `gcloud` flags

### DIFF
--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -49,13 +49,13 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
     gpg2 $COMMON_FLAGS --output generated_signature.pgp --local-user "${args[pgp_key_fingerprint]}" --armor --sign binauthz_signature_payload.json
     gcloud container binauthz attestations create \
         --artifact-url "$IMAGE_AND_DIGEST" \
-        --attestor="${args[attestor]}" \
-        --signature-file=./generated_signature.pgp \
-        --public-key-id="${args[pgp_key_fingerprint]}"
+        --attestor "${args[attestor]}" \
+        --signature-file ./generated_signature.pgp \
+        --public-key-id "${args[pgp_key_fingerprint]}"
 else
     gcloud beta container binauthz attestations sign-and-create \
-        --attestor="${args[attestor]}" \
+        --attestor "${args[attestor]}" \
         --artifact-url "$IMAGE_AND_DIGEST" \
-        --keyversion="${args[keyversion]}"
+        --keyversion "${args[keyversion]}"
 fi
 echo "Successfully created attestation"

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -55,7 +55,7 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
 else
     gcloud beta container binauthz attestations sign-and-create \
         --attestor="${args[attestor]}" \
-        --artifact-url="$IMAGE_AND_DIGEST" \
+        --artifact-url "$IMAGE_AND_DIGEST" \
         --keyversion="${args[keyversion]}"
 fi
 echo "Successfully created attestation"

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -35,7 +35,7 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
     fi
 
     gcloud container binauthz create-signature-payload \
-        --artifact-url="$IMAGE_AND_DIGEST" > binauthz_signature_payload.json
+        --artifact-url "$IMAGE_AND_DIGEST" > binauthz_signature_payload.json
 
     mkdir -p ~/.gnupg
     echo allow-loopback-pinentry > ~/.gnupg/gpg-agent.conf

--- a/binauthz-attestation/create_binauthz_attestation.sh
+++ b/binauthz-attestation/create_binauthz_attestation.sh
@@ -48,7 +48,7 @@ if [ -n "${args[pgp_key_fingerprint]}" ]; then
     echo -n "$PGP_SECRET_KEY" | gpg2 $COMMON_FLAGS --import
     gpg2 $COMMON_FLAGS --output generated_signature.pgp --local-user "${args[pgp_key_fingerprint]}" --armor --sign binauthz_signature_payload.json
     gcloud container binauthz attestations create \
-        --artifact-url="$IMAGE_AND_DIGEST" \
+        --artifact-url "$IMAGE_AND_DIGEST" \
         --attestor="${args[attestor]}" \
         --signature-file=./generated_signature.pgp \
         --public-key-id="${args[pgp_key_fingerprint]}"


### PR DESCRIPTION
## WHY

When I created a step as below:

```yaml
  - name: asia-northeast1-docker.pkg.dev/${PROJECT_ID}/tools/binauthz-attestation
    args:
      - --artifact-url
      - asia-northeast1-docker.pkg.dev/$PROJECT_ID/src/my-image:$_TAG
      - --attestor
      - projects/$PROJECT_ID/attestors/cloud-build-signer
      - --keyversion
      - projects/$PROJECT_ID/locations/asia-northeast1/keyRings/container_analysis/cryptoKeys/attestation_02/cryptoKeyVersions/1
```


I got this error message

```
Step #1: ERROR: (gcloud.beta.container.binauthz.attestations.sign-and-create) unrecognized arguments: "--artifact-url=$IMAGE_AND_DIGEST" (did you mean '--artifact-url'?) 
```

This is the fixture for it. I tested with this and worked 👍 