### PR TITLE
Fix ko build

### DIFF
--- a/ko/Dockerfile
+++ b/ko/Dockerfile
@@ -3,7 +3,7 @@ ARG KO_GIT_TAG
 
 RUN git clone --depth=1 -b "${KO_GIT_TAG}" https://github.com/google/ko
 WORKDIR ko
-RUN GOOS=linux go build -mod=vendor -o /bin/ko ./cmd/ko
+RUN GOOS=linux go build -mod=vendor -o /bin/ko
 
 FROM gcr.io/cloud-builders/kubectl
 


### PR DESCRIPTION
The ko project has removed `cmd/ko` per https://github.com/google/ko/pull/628 so this fix is required else the documented `gcloud builds submit` command will fail