### PR TITLE
ng: removed step v1 for broken python compatibility

### DIFF
--- a/ng/Dockerfile
+++ b/ng/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current
+FROM node:lts
 
 ARG ng_version=latest
 RUN npm install -g @angular/cli@$ng_version --unsafe-perms && \

--- a/ng/cloudbuild.yaml
+++ b/ng/cloudbuild.yaml
@@ -3,15 +3,6 @@ steps:
     args:
       [
         'build', '.',
-        '--tag=gcr.io/$PROJECT_ID/ng:v1',
-        '--file=Dockerfile',
-        '--build-arg', 'ng_version=1.*',
-      ]
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      [
-        'build', '.',
         '--tag=gcr.io/$PROJECT_ID/ng:v6',
         '--file=Dockerfile',
         '--build-arg', 'ng_version=6.*',
@@ -54,7 +45,6 @@ steps:
       ]
 
 images:
-  - 'gcr.io/$PROJECT_ID/ng:v1'
   - 'gcr.io/$PROJECT_ID/ng:v6'
   - 'gcr.io/$PROJECT_ID/ng:v7'
   - 'gcr.io/$PROJECT_ID/ng:v8'


### PR DESCRIPTION
It seems that `npm install -g @angular/cli@1.*` fails with missing _python2_ error

I've also retagged node base image with `lts` for [official supported Angular CLI version](https://angular.io/guide/setup-local#prerequisites)