### PR TITLE
Allow adding path inside the bucket.

### DIFF
--- a/cache/save_cache
+++ b/cache/save_cache
@@ -88,5 +88,5 @@ tar cpzf "$CACHE_FILE" ${PATHS[@]} -P
 
 if [ -n "$BUCKET" ];then
   echo "Uploading cache to Google Cloud Storage..."
-  gsutil -o GSUtil:parallel_composite_upload_threshold=${THRESHOLD} cp -R "$CACHE_FILE" "$BUCKET"
+  gsutil -o GSUtil:parallel_composite_upload_threshold=${THRESHOLD} cp -R "$CACHE_FILE" "$BUCKET/${KEY}.tgz"
 fi


### PR DESCRIPTION
If I add `--bucket=gs://$PROJECT_ID/__cache` as parameter for `save_cache` then object is stored as  `__cache` rather than using the key. 