### PR TITLE
Address line ending issue 443

### DIFF
--- a/firebase/.gitattributes
+++ b/firebase/.gitattributes
@@ -1,0 +1,1 @@
+firebase.bash text eol=lf 


### PR DESCRIPTION
This sets the attributes for the firebase.bash file to normalize firebase.bash to LF line endings so platform-related CRLF conversions don't turn it to CRLF which won't work with the cloud builders.

https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/443