### PR TITLE
Adopt latest Packer release

### DIFF
--- a/packer/cloudbuild.yaml
+++ b/packer/cloudbuild.yaml
@@ -12,8 +12,8 @@ steps:
            '--build-arg', 'PACKER_VERSION_SHA256SUM=${_PACKER_VERSION_SHA256SUM}',
            '.']
 substitutions:
-  _PACKER_VERSION: 1.7.8
-  _PACKER_VERSION_SHA256SUM: 8a94b84542d21b8785847f4cccc8a6da4c7be5e16d4b1a2d0a5f7ec5532faec0
+  _PACKER_VERSION: 1.8.2
+  _PACKER_VERSION_SHA256SUM: 675bd82561a2e49f89747e092141c7ce79c2e2a9105e6a2ebd49a26df849a468
 
 images:
   - 'gcr.io/$PROJECT_ID/packer:latest'


### PR DESCRIPTION
The current build for Packer installs Packer 1.7.8. Packer 1.7.9 (Nov 2021) supports using variables in the build name and it is useful in several contexts. This PR bumps to the present release of Packer, 1.8.2.