### PR TITLE
Fix schema error in kustomize/cloudbuild.yaml

### DIFF
--- a/kustomize/cloudbuild.yaml
+++ b/kustomize/cloudbuild.yaml
@@ -1,7 +1,8 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
     dir: ${_BUILD_DIRECTORY}
-    env: 'KUSTOMIZE_VERSION=${_KUSTOMIZE_VERSION}'
+    env:
+      - KUSTOMIZE_VERSION=${_KUSTOMIZE_VERSION}
     args:
       - build
       - --build-arg


### PR DESCRIPTION
I don't know how this happened but PR #476 introduced a schema error to `kustomize/cloudbuild.yaml`.

For some reason it sets `steps[0].env` property as string:

```
env: 'KUSTOMIZE_VERSION=${_KUSTOMIZE_VERSION}'
```

But `env` is expected to be an array, so CloudBuild can't read the `cloudbuild.yaml` file and shows this error when build is triggered:

> Your build failed to run: failed unmarshalling build config kustomize/cloudbuild.yaml: json: cannot unmarshal string into Go value of type []json.RawMessage

Maybe CloudBuild had accepted a string as `env` before, I don't know, but now it requires an array. So, this PR fixes this.