### PR TITLE
added link to offical images to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Build community images
 
 This repository contains source code for community-contributed Docker images. You can use these images as build steps for
-[Google Cloud Build](https://cloud.google.com/cloud-build/docs/).
+[Google Cloud Build](https://cloud.google.com/cloud-build/docs/) or use the [official builder images](https://github.com/GoogleCloudPlatform/cloud-builders)
 
 These are not official Google products.
 


### PR DESCRIPTION
The readme for this repo of the community maintained builders lacked a link back to the official images. I have added this to the readme to make this easier after confusion from a customer.