### PR TITLE
Add support for building a specific version of firebase-tools

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,14 +1,18 @@
 FROM node:lts-alpine3.14 AS app-env
 
+ARG FIREBASE_TOOLS_VERSION=latest
+
 # Install Python and Java and pre-cache emulator dependencies.
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
-    npm install -g firebase-tools && \
+    npm install -g firebase-tools@"$FIREBASE_TOOLS_VERSION" && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \
     firebase setup:emulators:storage && \
     firebase setup:emulators:ui && \
     rm -rf /var/cache/apk/*
+
+RUN echo "Successfull installed firebase-tools v$(firebase --version)"
 
 ADD firebase.bash /usr/bin
 RUN chmod +x /usr/bin/firebase.bash

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -17,6 +17,8 @@ The Firebase CLI can be authenticated in Cloud Build by one of two methods:
 1. **IAM Roles (preferred)** - grant Firebase IAM roles to the Cloud Build service account.
 1. **Firebase CLI Token** - use a CI token to authorize the Firebase CLI to act as an admin user.
 
+You can choose which version of `firebase-tools` to use by setting the substitution variable `_FIREBASE_TOOLS_VERSION` (default is `latest`). Specify desired version the same way as in `package.json`, for example `>=11.0.1 <12.0.0`, `latest`, `11.8.1` etc.
+
 ### With IAM roles
 
 Ensure you have the following APIs enabled

--- a/firebase/cloudbuild.yaml
+++ b/firebase/cloudbuild.yaml
@@ -1,6 +1,11 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/firebase', '--build-arg', 'FIREBASE_TOOLS_VERSION=$_FIREBASE_TOOLS_VERSION', '.']
 images:
 - 'gcr.io/$PROJECT_ID/firebase'
 tags: ['cloud-builders-community']
+
+options:
+  substitutionOption: ALLOW_LOOSE
+substitutions:
+  _FIREBASE_TOOLS_VERSION: latest


### PR DESCRIPTION
Currently it's not possible to specify a specific version of `firebase-tools` to build.

This PR adds an optional substitution variable `_FIREBASE_TOOLS_VERSION` that can be set in Cloud Build to specify which version of `firebase-tools` to install.

`_FIREBASE_TOOLS_VERSION` can be set to any value that `npm install firebase-tools@<version>` accepts, for example `>=11.0.1 <12.0.0`, `latest`, `11.8.1` etc.