### PR TITLE
Update packer example template

### DIFF
--- a/packer/examples/gce/build.pkr.hcl
+++ b/packer/examples/gce/build.pkr.hcl
@@ -12,12 +12,13 @@ variable "builder_sa" {
 
 source "googlecompute" "test-image" {
   project_id                  = var.project_id
-  source_image_family         = "ubuntu-2104"
+  source_image_family         = "ubuntu-2204-lts"
   zone                        = var.zone
   image_description           = "Created with Packer from Cloudbuild"
   ssh_username                = "root"
   tags                        = ["packer"]
   impersonate_service_account = var.builder_sa
+  temporary_key_pair_type     = "ed25519"
 }
 
 build {


### PR DESCRIPTION
When running packer to generate an image, the user will likely consider changing the template from ubuntu-2104 to ubuntu-2204, since that's a long term support version and it's newer.  After making that change, packer will fail.  The reason is not obvious. After logging into the build machine it says `userauth_pubkey: key type ssh-rsa not in PubkeyAcceptedAlgorithms `  The solution is to add `temporary_key_pair_type`.