### PR TITLE
Bump pack from 0.11.0 to 0.28.0

### DIFF
--- a/pack/Dockerfile
+++ b/pack/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-ENV PACK_VERSION=v0.11.0
+ENV PACK_VERSION=v0.28.0
 RUN wget -O- https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz | tar zx
 
 FROM gcr.io/distroless/base


### PR DESCRIPTION
This PR does the following:
- Updates Pack to release version 0.28.0