### PR TITLE
fix(helm): update to 3.12.0 and use gcloud auth plugin

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,20 +1,23 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v3.7.0
+ARG HELM_VERSION=v3.12.0
 ENV HELM_VERSION=$HELM_VERSION
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 COPY helm.bash /builder/helm.bash
 
 RUN chmod +x /builder/helm.bash && \
   mkdir -p /builder/helm && \
   apt-get update && \
-  apt-get install -y curl && \
+  apt-get install -y --no-install-recommends curl && \
   curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
   tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64 && \
   rm helm.tar.gz && \
   apt-get --purge -y autoremove && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN gcloud -q components install gke-gcloud-auth-plugin
 
 ENV PATH=/builder/helm/:$PATH
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -41,7 +41,7 @@ To build this builder, run the following command in this directory.
 
 You can also build this builder setting `Helm` version via in `cloudbuild.yaml`, no need to do that in `Dockerfile` anymore.
 
-    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v2.10.0', '.']
+    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v3.12.0', '.']
 
 ## Using Helm
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -11,4 +11,4 @@ images:
   - 'gcr.io/$PROJECT_ID/helm:latest'
 tags: ['cloud-builders-community']
 substitutions:
-  _HELM_VERSION: 3.7.0
+  _HELM_VERSION: 3.12.0


### PR DESCRIPTION
- Update helm to 3.12.0
- Add `--no-install-recommends` to `apt-get install`
- Install `gke-gcloud-auth-plugin`
- Set `USE_GKE_GCLOUD_AUTH_PLUGIN` to `True` in env

https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke has more context on this

Fixes #606