### PR TITLE
Add a Cloud Builder for CUE CLI

### DIFF
--- a/cue/Dockerfile
+++ b/cue/Dockerfile
@@ -1,0 +1,7 @@
+FROM busybox
+ENV CUE_VERSION=0.5.0
+RUN wget -O- https://github.com/cue-lang/cue/releases/download/v${CUE_VERSION}/cue_v${CUE_VERSION}_linux_amd64.tar.gz | tar zx
+
+FROM gcr.io/distroless/cc
+ENTRYPOINT ["/cue"]
+COPY --from=0 /cue /

--- a/cue/README.md
+++ b/cue/README.md
@@ -1,0 +1,14 @@
+# CUE
+
+[CUE](https://cuelang.org/) is a data constraint language for effective management of configurations, schemas and data.
+
+This build step invokes `cue` commands in [Google Cloud Build](cloud.google.com/cloud-build/).
+
+Arguments passed to this builder will be passed to `cue` directly, allowing
+callers to run [any CUE CLI command](https://cuetorials.com/overview/cli-commands/).
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    gcloud builds submit . --config=cloudbuild.yaml

--- a/cue/cloudbuild.yaml
+++ b/cue/cloudbuild.yaml
@@ -1,0 +1,11 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/${PROJECT_ID}/cue', '.']
+- name: 'gcr.io/${PROJECT_ID}/cue'
+  args: ['--help']
+
+images: ['gcr.io/${PROJECT_ID}/cue']
+tags: ['cloud-builders-community']


### PR DESCRIPTION
This PR introduces a Cloud Builder for [CUE](https://cuelang.org/), a data constraint language for effective management of configurations, schemas, and data.

The CUE CLI is useful when, for instance, generating YAML resource definitions for Kubernetes and Google Cloud Run from type-safe templates. 


A template file written in the CUE language can generate variations of YAML files based on input variables:

```cue
# template.cue

_env: "dev" | "stg" | "prd" @tag(env)
_project: "my-project-a" | "my-project-b" @tag(project)

apiVersion: "serving.knative.dev/v1"
kind:       "Service"
metadata: {
	name: "myservice-\(_env)"
}
spec: {
	template: {
		spec: {
			containers: [{
				name:  "nginx"
				image: "us-docker.pkg.dev/\(_project)/myrepo-\(_env)/nginx:latest"
			}]
		}
	}
}
```

```bash
$ cue eval template.cue -t env=dev -t project=my-project-a --out yaml 
              
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: myservice-dev
spec:
  template:
    spec:
      containers:
        - name: nginx
          image: us-docker.pkg.dev/my-project-a/myrepo-dev/nginx:latest
```

