### PR TITLE
Update Flutter Dockerfile

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -7,7 +7,7 @@
 # To build iOS applications, a Mac development environment is necessary.
 #
 
-FROM debian:stretch
+FROM debian:bookworm
 MAINTAINER Chinmay Garde <chinmaygarde@google.com>
 
 # Install Dependencies.


### PR DESCRIPTION
debian:stretch was causing a warning:

```
gcloud builds submit --region=<REGION> .
Step #0: WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Step #0: 
Step #0: Ign:1 http://deb.debian.org/debian stretch InRelease
Step #0: Ign:2 http://security.debian.org/debian-security stretch/updates InRelease
Step #0: Ign:3 http://deb.debian.org/debian stretch-updates InRelease
Step #0: Err:4 http://security.debian.org/debian-security stretch/updates Release
Step #0:   404  Not Found [IP: 151.101.130.132 80]
Step #0: Err:5 http://deb.debian.org/debian stretch Release
Step #0:   404  Not Found
Step #0: Err:6 http://deb.debian.org/debian stretch-updates Release
Step #0:   404  Not Found
Step #0: Reading package lists...
Step #0: E: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
Step #0: E: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
Step #0: E: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
Step #0: The command '/bin/sh -c apt update -y' returned a non-zero code: 100
Finished Step #0
ERROR
ERROR: build step 0 "docker:stable" failed: step exited with non-zero status: 100
```

cc: @chinmaygarde