### PR TITLE
Remove dev channel from Flutter configuration

### DIFF
--- a/flutter/cloudbuild.yaml
+++ b/flutter/cloudbuild.yaml
@@ -12,13 +12,6 @@ steps:
 - name: 'docker:stable'
   args: [
     'build', '.',
-    '-t', 'gcr.io/$PROJECT_ID/flutter:dev',
-    '--build-arg', 'channel=dev',
-  ]
-
-- name: 'docker:stable'
-  args: [
-    'build', '.',
     '-t', 'gcr.io/$PROJECT_ID/flutter:beta',
     '--build-arg', 'channel=beta',
   ]


### PR DESCRIPTION
The `dev` channel of the Flutter SDK is deprecated:

```
Step #1: Switching to flutter channel 'dev'...
Step #1: This channel is obsolete. Consider switching to the 'beta' channel instead.
```

cc @chinmaygarde