### PR TITLE
[Firebase] Update Alpine base image to 3.18 to support Python 3.11

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.14 AS app-env
+FROM node:lts-alpine3.18 AS app-env
 
 # Install Python and Java and pre-cache emulator dependencies.
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \


### PR DESCRIPTION


## Why:
- Current Firebase image uses Alpine 3.14, which installs Python 3.9 when `apk add python3`. (https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.14)
- Firebase Functions Python SDK needs Python 3.10+. (https://pypi.org/project/firebase-functions/)

## What:
- Updated Alpine to 3.18.
- Now `apk add python3` installs Python 3.11. (https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.18)


Please review. Thanks!