### PR TITLE
helmfile: fix dockerfile issues

### DIFF
--- a/helmfile/Dockerfile
+++ b/helmfile/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
-ARG HELM_VERSION=v3.6.3
-ARG HELMFILE_VERSION=v0.140.0
+ARG HELM_VERSION=v3.14.0
+ARG HELMFILE_VERSION=v0.161.0
 
 COPY helmfile.bash /builder/helmfile.bash
 
@@ -18,7 +18,9 @@ RUN chmod +x /builder/helmfile.bash && \
   curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
   tar zxvf helm.tar.gz --strip-components=1 -C /builder/helmfile linux-amd64 && \
   rm helm.tar.gz && \
-  curl -SsL https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64 > /builder/helmfile/helmfile && \
+  curl -fSsL https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION#v}_linux_amd64.tar.gz > /tmp/helmfile.tar.gz && \
+  tar zxvf /tmp/helmfile.tar.gz -C /builder/helmfile helmfile && \
+  rm /tmp/helmfile.tar.gz && \
   chmod 700 /builder/helmfile/helmfile && \
   /builder/helmfile/helm plugin install https://github.com/databus23/helm-diff
 

--- a/helmfile/cloudbuild.yaml
+++ b/helmfile/cloudbuild.yaml
@@ -5,9 +5,9 @@ steps:
         "build",
         "--tag=gcr.io/$PROJECT_ID/helmfile",
         "--build-arg",
-        "HELM_VERSION=v3.6.3",
+        "HELM_VERSION=v3.14.0",
         "--build-arg",
-        "HELMFILE_VERSION=v0.140.0",
+        "HELMFILE_VERSION=v0.161.0",
         ".",
       ]
 


### PR DESCRIPTION
Tried assembling/using this container in a Cloud Build recently, it didn't work as expected when running it:

```shellsession
Fetching cluster endpoint and auth data.
kubeconfig entry generated for acme-kube-cluster.
/builder/helmfile/helmfile: line 1: Not: command not found
```

(`/builder/helmfile/helmfile` is a 9-byte file with the contents `Not Found`)

These changes restore it to functional order:
* references the correct github repo/URI for the download (helmfile/helmfile)
* stages the tarball/extracts the `helmfile` properly
* added `-f` to the `curl` call so that, if the URI moves on the `helmfile` tarball again, it'll fail the container build
* update the default versions of both helm/helmfile in the yaml to the latest & greatest

The container both builds and runs as expected now:

```shellsession
Fetching cluster endpoint and auth data.
kubeconfig entry generated for acme-kube-cluster.
Adding repo acme-project https://acme.project.tld
"acme-project" has been added to your repositories
...
```