### PR TITLE
fix: sonarqube openjdk version upgraded from 11 to 17

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get install -y ca-certificates \
 	&& update-ca-certificates \
-	&& apt-get install -y openjdk-11-jdk-headless tzdata curl unzip bash \
+	&& apt-get install -y openjdk-17-jdk-headless tzdata curl unzip bash \
 	&& rm -rf /var/cache/apt/* \
     && mkdir -p /tmp/sonar-scanner  \
 	&& curl -L --silent ${SONAR_SCANNER_CLI_DOWNLOAD_URL} >  /tmp/sonar-scanner/sonar-scanner-cli-${SONARQUBE_SCANNER_CLI_VERSION}-linux.zip  \


### PR DESCRIPTION
This PR changes the version of openjdk on Sonarqube from 11 to 17.

Currently Sonarqube scanner throws the following error:
```bash
ERROR: Error during SonarScanner execution
ERROR: 

The version of Java (11.0.21) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
You can find more information here: https://docs.sonarsource.com/sonarcloud/appendices/scanner-environment/
```