### PR TITLE
use gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine; update to 3.15.4

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 
-ARG HELM_VERSION=v3.12.0
+ARG HELM_VERSION=v3.15.4
 ENV HELM_VERSION=$HELM_VERSION
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
@@ -8,16 +8,8 @@ COPY helm.bash /builder/helm.bash
 
 RUN chmod +x /builder/helm.bash && \
   mkdir -p /builder/helm && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends curl && \
-  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz && \
-  tar zxvf helm.tar.gz --strip-components=1 -C /builder/helm linux-amd64 && \
-  rm helm.tar.gz && \
-  apt-get --purge -y autoremove && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-
-RUN gcloud -q components install gke-gcloud-auth-plugin
+  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv --strip-components=1 -C /builder/helm linux-amd64 && \
+  gcloud -q components install gke-gcloud-auth-plugin
 
 ENV PATH=/builder/helm/:$PATH
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -41,7 +41,7 @@ To build this builder, run the following command in this directory.
 
 You can also build this builder setting `Helm` version via in `cloudbuild.yaml`, no need to do that in `Dockerfile` anymore.
 
-    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v3.12.0', '.']
+    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v3.15.4', '.']
 
 ## Using Helm
 
@@ -79,9 +79,4 @@ The following options are configurable via environment variables passed to the b
 
 | Option        | Description   |
 | ------------- | ------------- |
-| DIFF_PLUGIN_VERSION | [Diff plugin](https://github.com/databus23/helm-diff) version to install, optional |
-| GCS_PLUGIN_VERSION | [GCS plugin](https://github.com/nouney/helm-gcs) version to install, optional |
-| HELM_REPO_NAME | External Helm repository name, optional |
-| HELM_REPO_URL | External Helm repo URL, optional |
-| HELMFILE_VERSION | [Helmfile](https://github.com/roboll/helmfile) version to install, optional (if using helm v3, please use the helmfile builder)
-| SKIP_CLUSTER_CONFIG | If true, doesn't check or fetch GKE cluster config/creds, optional |
+| HELM_VERSION | [Helm](https://github.com/helm/helm) version to install, optional

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -11,4 +11,4 @@ images:
   - 'gcr.io/$PROJECT_ID/helm:latest'
 tags: ['cloud-builders-community']
 substitutions:
-  _HELM_VERSION: 3.12.0
+  _HELM_VERSION: 3.15.4


### PR DESCRIPTION
`google-cloud-cli:alpine` is smaller than currently used image -> Cloud Build step runs faster