### PR TITLE
Adding katalon tool support for cloud builder

### DIFF
--- a/katalon/Dockerfile
+++ b/katalon/Dockerfile
@@ -1,0 +1,6 @@
+FROM katalonstudio/katalon:9.6.0
+
+RUN apt-get -y update && \
+    apt-get -y install ca-certificates
+
+ENTRYPOINT ["sh"]

--- a/katalon/README.md
+++ b/katalon/README.md
@@ -1,0 +1,23 @@
+# Katalon in Google Cloud Build
+
+This demonstrates using the
+[`Katalon`](https://github.com/katalon-studio/docker-images) tool in Google Cloud
+Build to produce Docker images in a registry, instead of using `docker build`
+and `docker push`.
+
+## Steps:
+
+1. Modify the `cloudbuild.yaml` to define the steps to build your Docker image using Katalon.
+2. Define the custom `Dockerfile` for Katalon, which installs necessary packages and defines an entry point.
+3. Use the Cloud Build trigger to automate the process of building and pushing the Katalon image to your Container Registry, tagged with both `latest` and `9.6.0`.
+
+## Trigger the build locally
+
+To trigger the build locally using `gcloud`, navigate to your project root directory and run the following command:
+
+```bash
+gcloud builds submit --config=cloudbuild.yaml .
+```
+
+This command will submit your build to Cloud Build using the cloudbuild.yaml configuration file, which includes the steps for tagging the image with both latest and 9.6.0.
+

--- a/katalon/cloudbuild.yaml
+++ b/katalon/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: gcr.io/katalon-project/executor:latest
+  args: ['--destination=gcr.io/$PROJECT_ID/built-with-katalon:latest',
+         '--destination=gcr.io/$PROJECT_ID/built-with-katalon:9.6.0',
+         '--cache=true']
+tags: ['cloud-builders-community']


### PR DESCRIPTION
This Pull Request adds support for using the [Katalon](https://github.com/katalon-studio/docker-images) tool in Google Cloud Build. It includes the following changes:

Dockerfile:
- A new Dockerfile is added that uses the Katalon 9.6.0 image.
- Installs necessary certificates and defines the entry point.

cloudbuild.yaml:
- The Cloud Build configuration (cloudbuild.yaml) has been updated to support building and pushing Docker images tagged with both latest and 9.6.0.

README.md:
- The README.md file provides documentation on how to use Katalon in Google Cloud Build, including steps for triggering the build locally with gcloud builds submit.
- These updates make it easier to integrate Katalon into a CI/CD pipeline using Google Cloud Build.