### PR TITLE
Added harness-chaos cloud builder

### DIFF
--- a/harness-chaos/Dockerfile
+++ b/harness-chaos/Dockerfile
@@ -1,0 +1,10 @@
+FROM redhat/ubi8-minimal:8.8
+USER root
+# For future reference, do a minimal update of microdnf to avoid extra dependencies, minimizing vulnerabilities
+RUN microdnf update --refresh --best --noplugins --setopt=install_weak_deps=0 \
+ && rm -rf /var/cache/yum \
+ && microdnf clean all
+RUN microdnf install jq curl
+RUN curl -L https://app.harness.io/public/shared/tools/chaos/hce-cli/0.0.6/hce-cli-0.0.6-linux-amd64 --output /usr/local/bin/hce-cli && chmod +x /usr/local/bin/hce-cli
+USER 65534
+ENTRYPOINT ["hce-cli"]

--- a/harness-chaos/Dockerfile
+++ b/harness-chaos/Dockerfile
@@ -5,6 +5,6 @@ RUN microdnf update --refresh --best --noplugins --setopt=install_weak_deps=0 \
  && rm -rf /var/cache/yum \
  && microdnf clean all
 RUN microdnf install jq curl
-RUN curl -L https://app.harness.io/public/shared/tools/chaos/hce-cli/0.0.6/hce-cli-0.0.6-linux-amd64 --output /usr/local/bin/hce-cli && chmod +x /usr/local/bin/hce-cli
+RUN curl -L https://app.harness.io/public/shared/tools/chaos/hce-cli/latest/hce-cli-latest-linux-amd64 --output /usr/local/bin/hce-cli && chmod +x /usr/local/bin/hce-cli
 USER 65534
 ENTRYPOINT ["hce-cli"]

--- a/harness-chaos/Dockerfile
+++ b/harness-chaos/Dockerfile
@@ -1,6 +1,5 @@
 FROM redhat/ubi8-minimal:8.8
 USER root
-# For future reference, do a minimal update of microdnf to avoid extra dependencies, minimizing vulnerabilities
 RUN microdnf update --refresh --best --noplugins --setopt=install_weak_deps=0 \
  && rm -rf /var/cache/yum \
  && microdnf clean all

--- a/harness-chaos/README.md
+++ b/harness-chaos/README.md
@@ -10,14 +10,6 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/harness-chaos'
   args: ['generate', '--api=run-and-monitor-experiment', '--account-id=${_ACCOUNT_ID}','--org-id=${_ORG_ID}','--project-id=${_PROJECT_ID}', '--workflow-id=${_EXPERIMENT_ID}', '--expected-resilience-score=${_EXPECTED_RES_SCORE}', '--api-key=${_X_API_KEY}' ]
 
-  env:
-    - 'ACCOUNT_ID=${_ACCOUNT_ID}'
-    - 'ORG_ID=${_ORG_ID}'
-    - 'PROJECT_ID=${_PROJECT_ID}'
-    - 'WORKFLOW_ID=${_EXPERIMENT_ID}'
-    - 'EXPECTED_RES_SCORE=${_EXPECTED_RES_SCORE}'
-    - 'X_API_KEY=${_X_API_KEY}'
-
 substitutions:
   _ACCOUNT_ID: '<ACCOUNT_ID>'
   _ORG_ID: 'ORG_ID'
@@ -26,3 +18,5 @@ substitutions:
   _EXPECTED_RES_SCORE: '100'
   _X_API_KEY: 'X_API_KEY' // required for authorization
 ```
+
+To know more about Harness Chaos Engineering visit [here](https://developer.harness.io/docs/chaos-engineering).

--- a/harness-chaos/README.md
+++ b/harness-chaos/README.md
@@ -1,8 +1,26 @@
 # Harness Chaos
 
-The harness-chaos builder step is used to launch chaos experiments and test the resilience of the applications.
+## Introduction
+The harness-chaos builder step is used to launch chaos experiments and test the resilience of the applications. This tool helps users easily simulate various failure scenarios and uncover potential vulnerabilities and weaknesses in the system/applications.This can be integrated with the CD pipelines to test the resiliency of the application before doing the releases
 
-Here’s an example demonstrating how to launch and validate a chaos experiment. You can pass the `--workflow-id` flag along with the `--expected-resilience-score` flag to ensure that the actual resilience score of the experiment run meets the expected threshold, along with other necessary flags.
+## Prerequisites
+
+**Identifiers(Account ID, Organization ID, Project ID)**
+
+To perform any operation in Harness Chaos Engineering(HCE) platform, users need to get onboarded and have the identifiers. Here are the references to get started:
+- [User Onboarding Guide](https://developer.harness.io/docs/platform/get-started/onboarding-guide) 
+- [Create organizations and projects](https://developer.harness.io/docs/platform/organizations-and-projects/create-an-organization)
+
+**Create API Key**
+To run any operation, users will need an API Key to authorize the same. API Key needs to be created and passed as flag in the command demonstrated below. Here is the document to [create and manage API keys](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/).
+
+**Create a Chaos Experiment**
+
+Next step is to create a chaos experiment and get the experiment ID to launch the chaos experiment using cloud builder. Once the onboarding is complete, users can go to the Chaos Engineering Module and follow the steps mentioned in documentation to [create a chaos experiment](https://developer.harness.io/docs/chaos-engineering/get-started/tutorials/chaos-experiment-from-blank-canvas).
+
+## How to run launch chaos experiment using cloud builder
+
+Once the chaos experiment is created and we have the values for the required flags, here’s an example demonstrating how to launch and validate a chaos experiment using cloud builder. Users can pass the `--workflow-id` flag(`workflow-id` is same as experiment ID) along with the `--expected-resilience-score` flag to ensure that the actual resilience score of the experiment run meets the expected threshold, along with other necessary flags.
 
 **Example:**
 ```
@@ -18,5 +36,16 @@ substitutions:
   _EXPECTED_RES_SCORE: '100'
   _X_API_KEY: 'X_API_KEY' // required for authorization
 ```
+
+### Flags
+
+- `--api`: Set the name of the target API (mandatory).
+- `--account-id`: Set the account ID (mandatory).
+- `--org-id`: Set the organisation id (default "default")
+- `--project-id`: Set the HCE project ID (mandatory).
+- `--workflow-id`: Set the workflow ID (mandatory for some APIs; a default dummy value is provided).
+- `--api-key`: Set the API key (mandatory).
+- `--delay`: Set the delay provided for multiple iterations (a default value of 2s is provided for some APIs).
+- `--timeout`: Set the timeout provided for multiple iterations (a default value of 180s is provided for some APIs).
 
 To know more about Harness Chaos Engineering visit [here](https://developer.harness.io/docs/chaos-engineering).

--- a/harness-chaos/README.md
+++ b/harness-chaos/README.md
@@ -1,0 +1,28 @@
+# Harness Chaos
+
+The harness-chaos builder step is used to launch chaos experiments and test the resilience of the applications.
+
+Here’s an example demonstrating how to launch and validate a chaos experiment. You can pass the `--workflow-id` flag along with the `--expected-resilience-score` flag to ensure that the actual resilience score of the experiment run meets the expected threshold, along with other necessary flags.
+
+**Example:**
+```
+steps:
+- name: 'gcr.io/$PROJECT_ID/harness-chaos'
+  args: ['generate', '--api=run-and-monitor-experiment', '--account-id=${_ACCOUNT_ID}','--org-id=${_ORG_ID}','--project-id=${_PROJECT_ID}', '--workflow-id=${_EXPERIMENT_ID}', '--expected-resilience-score=${_EXPECTED_RES_SCORE}', '--api-key=${_X_API_KEY}' ]
+
+  env:
+    - 'ACCOUNT_ID=${_ACCOUNT_ID}'
+    - 'ORG_ID=${_ORG_ID}'
+    - 'PROJECT_ID=${_PROJECT_ID}'
+    - 'WORKFLOW_ID=${_EXPERIMENT_ID}'
+    - 'EXPECTED_RES_SCORE=${_EXPECTED_RES_SCORE}'
+    - 'X_API_KEY=${_X_API_KEY}'
+
+substitutions:
+  _ACCOUNT_ID: '<ACCOUNT_ID>'
+  _ORG_ID: 'ORG_ID'
+  _PROJECT_ID: 'PROJECT_ID'
+  _EXPERIMENT_ID: 'EXPERIMENT_ID'
+  _EXPECTED_RES_SCORE: '100'
+  _X_API_KEY: 'X_API_KEY' // required for authorization
+```

--- a/harness-chaos/README.md
+++ b/harness-chaos/README.md
@@ -30,11 +30,11 @@ steps:
 
 substitutions:
   _ACCOUNT_ID: '<ACCOUNT_ID>'
-  _ORG_ID: 'ORG_ID'
-  _PROJECT_ID: 'PROJECT_ID'
-  _EXPERIMENT_ID: 'EXPERIMENT_ID'
+  _ORG_ID: '<ORG_ID>'
+  _PROJECT_ID: '<PROJECT_ID>'
+  _EXPERIMENT_ID: '<EXPERIMENT_ID>'
   _EXPECTED_RES_SCORE: '100'
-  _X_API_KEY: 'X_API_KEY' // required for authorization
+  _X_API_KEY: '<X_API_KEY>' // required for authorization
 ```
 
 ### Flags

--- a/harness-chaos/cloudbuild.yaml
+++ b/harness-chaos/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/harness-chaos', '.']
+
+# To ensure tool is installed correctly
+- name: 'gcr.io/$PROJECT_ID/harness-chaos'
+  args: ['generate', '--help']
+
+images: ['gcr.io/$PROJECT_ID/harness-chaos']


### PR DESCRIPTION
This PR adds support for using the [Harness Chaos Engineering](https://app.harness.io/) platform in Google Cloud Build. It includes the following changes:

1. A new Dockerfile is added to download latest released binary for hce-cli (CLI tool to introduce chaos experiments into the target environment. This allows the users to test the resilience of your systems and applications), build it and and define the entry point.
2. The Cloud Build configuration (cloudbuild.yaml) has been added to support building and pushing Docker images along with running the hce-cli help command.
3. The README.md file contains documentation on how to use Harness Chaos Engineering in Google Cloud Build, including steps for launching chaos experiments and validating the resiliency score.
