### PR TITLE
Update alpine version to 3.20 in firebase

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.18 AS app-env
+FROM node:lts-alpine3.20 AS app-env
 
 # Install Python and Java and pre-cache emulator dependencies.
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \


### PR DESCRIPTION
Firebase Cloud Functions will retire the Node 16 runtime in January 2026. The currently runtime available in Firebase Builder is 18, but the latest LTS version is 20.