### PR TITLE
firebase README: Note for Windows users to convert line endings to LF

### DIFF
--- a/firebase/README.md
+++ b/firebase/README.md
@@ -90,3 +90,14 @@ secrets:
 ## Examples
 
 See examples in the `examples` subdirectory.
+
+## Note for Windows Users
+
+If you're using Windows, the `firebase.bash` script might have CRLF (Carriage Return Line Feed) line endings, which can cause issues in Linux-based environments (such as Docker). Before submitting your build, you will need to convert the line endings to LF (Line Feed) to ensure compatibility.
+
+To convert the file, run the following command:
+
+```bash
+dos2unix firebase.bash
+```
+


### PR DESCRIPTION
…n firebase.bash to LF

This update adds a section to the README that instructs Windows users to run the `dos2unix` command on the `firebase.bash` file to convert line endings from CRLF to LF. 

On Windows machines, the default line endings are CRLF (Carriage Return Line Feed), while Linux-based environments (such as Docker) expect LF (Line Feed) line endings. If the `firebase.bash` file is not converted to LF, it may fail to execute properly, leading to errors like "no such file or directory" during the build process.

By adding this instruction, we ensure that users on Windows machines are aware of the potential issue and can resolve it before submitting or building the Docker image.