### PR TITLE
Remove Flutter dev channel image

### DIFF
--- a/flutter/cloudbuild.yaml
+++ b/flutter/cloudbuild.yaml
@@ -31,7 +31,6 @@ timeout: '1200s'
 
 images: [
   'gcr.io/$PROJECT_ID/flutter:master',
-  'gcr.io/$PROJECT_ID/flutter:dev',
   'gcr.io/$PROJECT_ID/flutter:beta',
   'gcr.io/$PROJECT_ID/flutter:stable',
   'gcr.io/$PROJECT_ID/flutter',


### PR DESCRIPTION
The check fails:
```
BUILD FAILURE: Build step failure: Image(s) gcr.io/<project>/flutter:dev could not be found. Check if image(s) exists in the repository.
```