### PR TITLE
fix: firebase-tools openjdk version upgraded from 11 to 17

### DIFF
--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine3.20 AS app-env
 
 # Install Python and Java and pre-cache emulator dependencies.
-RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
+RUN apk add --no-cache python3 py3-pip openjdk21-jre bash && \
     npm install -g firebase-tools && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \


### PR DESCRIPTION
This PR upgrades OpenJDK in the Dockerfile from version 11 to 21.

`firebase-tools` currently emits the following warning:
```bash
⬢  emulators: firebase-tools will drop support for Java version < 21 soon in firebase-tools@15. Please install a JDK at version 21 or above to get a compatible runtime.
i  emulators: Starting emulators: auth, firestore, storage
```