### PR TITLE
Adding versioning of terraform

### DIFF
--- a/gcluster/Dockerfile
+++ b/gcluster/Dockerfile
@@ -16,13 +16,15 @@ RUN make gcluster
 
 FROM gcr.io/cloud-builders/gcloud
 
+ARG TERRAFORM_VERSION
+
 RUN apt-get update && apt-get install -y gnupg software-properties-common curl wget         \
     && install -m 0755 -d /etc/apt/keyrings         \
     && curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg         \
     && chmod a+r /etc/apt/keyrings/hashicorp.gpg         \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list > /dev/null         \
     && apt-get update \
-    && apt-get install -y terraform packer         \
+    && apt-get install -y terraform=${TERRAFORM_VERSION:-} packer         \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/gcluster /usr/local/bin/gcluster


### PR DESCRIPTION
Getting this error:

Step #3:   on modules/embedded/community/modules/pubsub/topic/versions.tf line 18, in terraform:
Step #3:   18:   required_version = "= 1.12.2"

Need to be able to force the Terraform version.