### PR TITLE
Update gcloud builder to accept versions ARG for packer and terraform

### DIFF
--- a/gcluster/Dockerfile
+++ b/gcluster/Dockerfile
@@ -21,28 +21,19 @@ ARG TERRAFORM_VERSION=1.12.2
 ARG PACKER_VERSION=1.12.0
 ARG ARCH=amd64
 
-# RUN apt-get update && apt-get install -y gnupg software-properties-common curl wget         \
-#     && install -m 0755 -d /etc/apt/keyrings         \
-#     && curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg         \
-#     && chmod a+r /etc/apt/keyrings/hashicorp.gpg         \
-#     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list > /dev/null         \
-#     && apt-get update \
-#     && apt-get install -y terraform=${TERRAFORM_VERSION:-} packer         \
-#     && rm -rf /var/lib/apt/lists/*
-
 # Install dependencies, download, unzip, and clean up
 RUN apt-get update && apt-get install -y curl unzip && \
     curl -sLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
-    mv terraform /usr/local/bin/ && \
+    unzip -o terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+    mv -f terraform /usr/local/bin/ && \
     rm terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # Install dependencies, download, unzip, and move to path
 RUN curl -sLO https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
-    unzip packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
-    mv packer /usr/local/bin/ && \
+    unzip -o packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
+    mv -f packer /usr/local/bin/ && \
     rm packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/gcluster/Dockerfile
+++ b/gcluster/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25.1-bookworm as builder
 
-ARG GCLUSTER_VERSION
+ARG GCLUSTER_VERSION=1.1
 
 RUN apt-get update && apt-get install -y \
     git \
@@ -16,16 +16,35 @@ RUN make gcluster
 
 FROM gcr.io/cloud-builders/gcloud
 
-ARG TERRAFORM_VERSION
+# Define version and architecture
+ARG TERRAFORM_VERSION=1.12.2
+ARG PACKER_VERSION=1.12.0
+ARG ARCH=amd64
 
-RUN apt-get update && apt-get install -y gnupg software-properties-common curl wget         \
-    && install -m 0755 -d /etc/apt/keyrings         \
-    && curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg         \
-    && chmod a+r /etc/apt/keyrings/hashicorp.gpg         \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list > /dev/null         \
-    && apt-get update \
-    && apt-get install -y terraform=${TERRAFORM_VERSION:-} packer         \
-    && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y gnupg software-properties-common curl wget         \
+#     && install -m 0755 -d /etc/apt/keyrings         \
+#     && curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg         \
+#     && chmod a+r /etc/apt/keyrings/hashicorp.gpg         \
+#     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list > /dev/null         \
+#     && apt-get update \
+#     && apt-get install -y terraform=${TERRAFORM_VERSION:-} packer         \
+#     && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies, download, unzip, and clean up
+RUN apt-get update && apt-get install -y curl unzip && \
+    curl -sLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+    mv terraform /usr/local/bin/ && \
+    rm terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+
+# Install dependencies, download, unzip, and move to path
+RUN curl -sLO https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
+    unzip packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
+    mv packer /usr/local/bin/ && \
+    rm packer_${PACKER_VERSION}_linux_${ARCH}.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/gcluster /usr/local/bin/gcluster
 

--- a/gcluster/Dockerfile
+++ b/gcluster/Dockerfile
@@ -16,13 +16,15 @@ RUN make gcluster
 
 FROM gcr.io/cloud-builders/gcloud
 
+ARG TERRAFORM_VERSION
+
 RUN apt-get update && apt-get install -y gnupg software-properties-common curl wget         \
     && install -m 0755 -d /etc/apt/keyrings         \
     && curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /etc/apt/keyrings/hashicorp.gpg         \
     && chmod a+r /etc/apt/keyrings/hashicorp.gpg         \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list > /dev/null         \
     && apt-get update \
-    && apt-get install -y terraform packer         \
+    && apt-get install -y terraform=${TERRAFORM_VERSION:-} packer         \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/gcluster /usr/local/bin/gcluster


### PR DESCRIPTION
Running some of the gcluster modules requires terraform to be at v1.12.2. This causes failures when doing a "gcluster deploy" command for certain version locked Cluster Toolkit modules.